### PR TITLE
[Feat] 회원가입 시 Role 필드 저장 기능 추가

### DIFF
--- a/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
+++ b/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
@@ -1,5 +1,8 @@
 package uniqram.c1one.auth.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,8 +11,19 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class SignupRequest {
+
+    @NotBlank
+    @Size(min = 2, max = 20)
     private String username;
+
+    @NotBlank
+    @Size(min = 6, max = 100)
     private String password;
+
+    @NotBlank
     private String confirmPassword;
+
+    @NotBlank
+    @Email
     private String email;
 }

--- a/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
+++ b/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import uniqram.c1one.user.entity.Role;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -26,4 +28,6 @@ public class SignupRequest {
     @NotBlank
     @Email
     private String email;
+
+    private Role role;
 }

--- a/src/main/java/uniqram/c1one/auth/service/AuthService.java
+++ b/src/main/java/uniqram/c1one/auth/service/AuthService.java
@@ -1,9 +1,9 @@
 package uniqram.c1one.auth.service;
 
 import uniqram.c1one.auth.dto.SignupRequest;
+import uniqram.c1one.user.entity.Role;
 import uniqram.c1one.user.entity.Users;
 import uniqram.c1one.user.repository.UserRepository;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -23,14 +23,21 @@ public class AuthService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 중복 체크
         if (userRepository.findByUsername(request.getUsername()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        Users user = new Users(request.getUsername(), encodedPassword);
+        Role role = request.getRole() != null ? request.getRole() : Role.USER;
+
+        Users user = new Users(
+                request.getUsername(),
+                encodedPassword,
+                request.getEmail(),
+                role
+        );
+
         userRepository.save(user);
     }
 }

--- a/src/main/java/uniqram/c1one/user/entity/Role.java
+++ b/src/main/java/uniqram/c1one/user/entity/Role.java
@@ -1,0 +1,6 @@
+package uniqram.c1one.user.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/uniqram/c1one/user/entity/Users.java
+++ b/src/main/java/uniqram/c1one/user/entity/Users.java
@@ -18,10 +18,16 @@ public class Users extends BaseEntity {
 
     private String email;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     protected Users(){}
 
-    public Users(String username, String password) {
+    public Users(String username, String password, String email, Role role) {
         this.username = username;
         this.password = password;
+        this.email = email;
+        this.role = role;
     }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
회원가입 시 사용자에게 Role 필드를 저장하도록 기능 추가

## 🛠️ 작업 내용
- SignupRequest DTO에 `Role` 필드 추가
- `AuthService`에서 Role이 null이면 기본값 `USER`로 설정
- Users 엔티티에 Role 필드 있는 생성자 활용


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
#15 
<!--- closes #이슈번호 ex) closes #123 -->

