### PR TITLE
[Feat] 게시물 등록 api에 media 추가 및 홈/프로필 게시물 조회 API 개발

### DIFF
--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -1,14 +1,15 @@
 package uniqram.c1one.post.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.global.success.SuccessResponse;
+import uniqram.c1one.post.dto.HomePostResponse;
 import uniqram.c1one.post.dto.PostRequest;
 import uniqram.c1one.post.dto.PostResponse;
+import uniqram.c1one.post.dto.UserPostResponse;
 import uniqram.c1one.post.exception.PostSuccessCode;
 import uniqram.c1one.post.service.PostService;
 
@@ -20,10 +21,31 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<SuccessResponse<PostResponse>> createPost(@RequestBody PostRequest postRequest) {
+    public ResponseEntity<SuccessResponse<PostResponse>> createPost(
+            @RequestBody @Valid PostRequest postRequest
+    ) {
         Long userId = postRequest.getUserId();
         PostResponse postResponse = postService.createPost(userId, postRequest);
         return ResponseEntity.status(PostSuccessCode.POST_CREATED.getStatus())
                 .body(SuccessResponse.of(PostSuccessCode.POST_CREATED, postResponse));
+    }
+
+    @GetMapping("/posts/home")
+    public ResponseEntity<Page<HomePostResponse>> getHomePosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<HomePostResponse> homePosts = postService.getHomePosts(page, size);
+        return ResponseEntity.ok(homePosts);
+    }
+
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<Page<UserPostResponse>> getUserPosts(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<UserPostResponse> posts = postService.getUserPosts(userId, page, size);
+        return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
@@ -8,22 +8,22 @@ import java.util.List;
 
 @Getter
 @Builder
-public class PostResponse {
+public class HomePostResponse {
 
     private Long postId;
     private String content;
     private String location;
 
-    private List<String>  mediaUrls;
-
-    private int likeCount;
-    private int commentCount;
+    private List<String> mediaUrls;
 
     private Long memberId;
     private String nickname;
 
-    public static PostResponse from(Post post, List<String> mediaUrl) {
-        return PostResponse.builder()
+    private int likeCount;
+    private int commentCount;
+
+    public static HomePostResponse from(Post post, List<String> mediaUrl) {
+        return HomePostResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .location(post.getLocation())

--- a/src/main/java/uniqram/c1one/post/dto/PostRequest.java
+++ b/src/main/java/uniqram/c1one/post/dto/PostRequest.java
@@ -1,6 +1,9 @@
 package uniqram.c1one.post.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Builder(toBuilder = true)
@@ -11,4 +14,7 @@ public class PostRequest {
     private Long userId;   // 임시 포함
     private String content;
     private String location;
+
+    @NotEmpty
+    private List<String> mediaUrls;
 }

--- a/src/main/java/uniqram/c1one/post/dto/UserPostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/UserPostResponse.java
@@ -1,0 +1,20 @@
+package uniqram.c1one.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import uniqram.c1one.post.entity.Post;
+
+@Getter
+@Builder
+public class UserPostResponse {
+
+    private Long postId;
+    private String representativeImageUrl;
+
+    public static UserPostResponse from(Post post, String repImageUrl) {
+        return UserPostResponse.builder()
+                .postId(post.getId())
+                .representativeImageUrl(repImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/post/entity/Post.java
+++ b/src/main/java/uniqram/c1one/post/entity/Post.java
@@ -32,6 +32,7 @@ public class Post extends BaseEntity {
     private String location;
 
     private int likeCount;
+    private int commentCount;
 
     // 고급 설정
     private Boolean hideLikeAndViewCount = false;

--- a/src/main/java/uniqram/c1one/post/exception/PostErrorCode.java
+++ b/src/main/java/uniqram/c1one/post/exception/PostErrorCode.java
@@ -8,7 +8,8 @@ import uniqram.c1one.global.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum PostErrorCode implements ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "이미지는 필수 입력 값입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -1,7 +1,6 @@
 package uniqram.c1one.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.PostMedia;
@@ -12,8 +11,7 @@ import java.util.Optional;
 @Repository
 public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
 
-    @Query("SELECT pm.mediaUrl FROM PostMedia pm WHERE pm.post.id = :postId ORDER BY pm.id ASC")
-    Optional<String> findFirstImageUrlByPostId(@Param("postId") Long postId);
+    Optional<PostMedia> findFirstByPostIdOrderByIdAsc(@Param("postId") Long postId);
 
     List<PostMedia> findByPostIdOrderByIdAsc(Long postId);
 }

--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -1,0 +1,19 @@
+package uniqram.c1one.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import uniqram.c1one.post.entity.PostMedia;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
+
+    @Query("SELECT pm.mediaUrl FROM PostMedia pm WHERE pm.post.id = :postId ORDER BY pm.id ASC")
+    Optional<String> findFirstImageUrlByPostId(@Param("postId") Long postId);
+
+    List<PostMedia> findByPostIdOrderByIdAsc(Long postId);
+}

--- a/src/main/java/uniqram/c1one/post/repository/PostRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostRepository.java
@@ -1,5 +1,7 @@
 package uniqram.c1one.post.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.Post;
@@ -7,6 +9,9 @@ import uniqram.c1one.post.entity.Post;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-//    @Query("SELECT p FROM Post p JOIN FETCH p.mediaList WHERE p.id = :id")
-//    Optional<Post> findByIdWithMedia(@Param("id") Long id);
+    // 전체 게시글을 최신순 조회(홈화면용)
+    Page<Post> findAllByOrderByIdDesc(Pageable pageable);
+
+    // 특정 사용자의 게시글 리스트
+    Page<Post> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/uniqram/c1one/post/service/PostService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostService.java
@@ -1,16 +1,27 @@
 package uniqram.c1one.post.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.post.dto.HomePostResponse;
 import uniqram.c1one.post.dto.PostRequest;
 import uniqram.c1one.post.dto.PostResponse;
+import uniqram.c1one.post.dto.UserPostResponse;
 import uniqram.c1one.post.entity.Post;
+import uniqram.c1one.post.entity.PostMedia;
 import uniqram.c1one.post.exception.PostErrorCode;
 import uniqram.c1one.post.exception.PostException;
+import uniqram.c1one.post.repository.PostMediaRepository;
 import uniqram.c1one.post.repository.PostRepository;
 import uniqram.c1one.user.entity.Users;
 import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,20 +29,65 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final PostMediaRepository postMediaRepository;
 
     @Transactional
     public PostResponse createPost(Long userId, PostRequest postRequest) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
 
-        Post post = Post.of(user, postRequest.getContent(), postRequest.getLocation());
+        // 이미지 필수
+        if (postRequest.getMediaUrls() == null || postRequest.getMediaUrls().isEmpty()) {
+            throw new PostException(PostErrorCode.IMAGE_REQUIRED);
+        }
 
+        Post post = Post.of(user, postRequest.getContent(), postRequest.getLocation());
         postRepository.save(post);
 
-        return PostResponse.builder()
-                .postId(post.getId())
-                .content(post.getContent())
-                .location(post.getLocation())
-                .build();
+        // 이미지 등록
+        if (postRequest.getMediaUrls() != null && !postRequest.getMediaUrls().isEmpty()) {
+            List<PostMedia> mediaList = postRequest.getMediaUrls().stream()
+                    .map(url -> PostMedia.of(post, url))
+                    .toList();
+            postMediaRepository.saveAll(mediaList);
+        }
+
+        List<String> mediaUrls = postMediaRepository.findByPostIdOrderByIdAsc(post.getId())
+                .stream()
+                .map(PostMedia::getMediaUrl)
+                .collect(Collectors.toList());
+
+        return PostResponse.from(post, mediaUrls);
+    }
+
+    @Transactional(readOnly = true) // TODO: N+1 문제 발생 가능성 있음. PostMedia IN 쿼리로 개선 예정.
+    public Page<HomePostResponse> getHomePosts(int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Post> postPage = postRepository.findAllByOrderByIdDesc(pageable);
+
+        return postPage.map(post -> {
+            List<String> mediaUrls = postMediaRepository.findByPostIdOrderByIdAsc(post.getId())
+                    .stream()
+                    .map(PostMedia::getMediaUrl)
+                    .collect(Collectors.toList());
+
+            return HomePostResponse.from(post, mediaUrls);
+        });
+    }
+
+    @Transactional(readOnly = true) // TODO: N+1 문제 발생 가능성 있음. PostMedia IN 쿼리로 개선 예정.
+    public Page<UserPostResponse> getUserPosts(Long userId, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Post> postPage = postRepository.findByUserIdOrderByIdDesc(userId, pageable);
+
+        return postPage.map(post -> {
+
+            String repImageUrl = postMediaRepository.findFirstImageUrlByPostId(post.getId())
+                    .orElseThrow(() -> new PostException(PostErrorCode.IMAGE_REQUIRED));
+
+            return UserPostResponse.from(post, repImageUrl);
+        });
     }
 }

--- a/src/main/java/uniqram/c1one/post/service/PostService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostService.java
@@ -84,7 +84,8 @@ public class PostService {
 
         return postPage.map(post -> {
 
-            String repImageUrl = postMediaRepository.findFirstImageUrlByPostId(post.getId())
+            String repImageUrl = postMediaRepository.findFirstByPostIdOrderByIdAsc(post.getId())
+                    .map(PostMedia::getMediaUrl)
                     .orElseThrow(() -> new PostException(PostErrorCode.IMAGE_REQUIRED));
 
             return UserPostResponse.from(post, repImageUrl);

--- a/src/main/java/uniqram/c1one/user/entity/Users.java
+++ b/src/main/java/uniqram/c1one/user/entity/Users.java
@@ -1,6 +1,7 @@
 package uniqram.c1one.user.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import uniqram.c1one.comment.entity.Comment;
 import uniqram.c1one.global.BaseEntity;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 
 @Entity
+@Getter
 public class Users extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
게시물 등록 시 media 등록 필수 처리 및 홈·프로필 게시물 조회 API 개발

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 게시물 등록 API에 mediaUrls 필수 로직 추가
- PostMedia 엔티티 기반 이미지 저장 처리
- 홈화면 게시물 조회 API 개발 (게시물 + 전체 이미지 리스트 반환)
- 특정 사용자 프로필 게시물 조회 API 개발 (대표 이미지 1장 반환)
- 관련 DTO, Repository, Service 로직 추가

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 홈 게시물 조회, 프로필 게시물 조회 모두 추후 N+1 방지 쿼리 개선 예정입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

-------------
closes #24 