### PR TITLE
Refactor: 회원가입 예외처리 리팩토링

### DIFF
--- a/src/main/java/uniqram/c1one/auth/exception/AuthErrorCode.java
+++ b/src/main/java/uniqram/c1one/auth/exception/AuthErrorCode.java
@@ -1,0 +1,17 @@
+package uniqram.c1one.auth.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import uniqram.c1one.global.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/uniqram/c1one/auth/exception/AuthException.java
+++ b/src/main/java/uniqram/c1one/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package uniqram.c1one.auth.exception;
+
+import uniqram.c1one.global.exception.BaseException;
+import uniqram.c1one.global.exception.ErrorCode;
+
+public class AuthException extends BaseException {
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/uniqram/c1one/auth/service/AuthService.java
+++ b/src/main/java/uniqram/c1one/auth/service/AuthService.java
@@ -1,11 +1,13 @@
 package uniqram.c1one.auth.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 import uniqram.c1one.auth.dto.SignupRequest;
+import uniqram.c1one.auth.exception.AuthErrorCode;
+import uniqram.c1one.auth.exception.AuthException;
 import uniqram.c1one.user.entity.Role;
 import uniqram.c1one.user.entity.Users;
 import uniqram.c1one.user.repository.UserRepository;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
 
 @Service
 public class AuthService {
@@ -20,11 +22,11 @@ public class AuthService {
 
     public void signup(SignupRequest request) {
         if (!request.getPassword().equals(request.getConfirmPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new AuthException(AuthErrorCode.PASSWORD_MISMATCH);
         }
 
         if (userRepository.findByUsername(request.getUsername()).isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+            throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
회원가입 로직에서 `IllegalArgumentException` 대신 도메인 전용 예외(AuthException, AuthErrorCode)를 사용하도록 리팩토링
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- `AuthException` 클래스 생성 (BaseException 상속)
- `AuthErrorCode` enum 정의 및 메시지 추가
- `AuthService` 내 회원가입 실패 시 커스텀 예외 사용


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #59
<!--- closes #이슈번호 ex) closes #123 -->

