### PR TITLE
[Refactor] 회원가입 요청에서 사용자 역할 제거

### DIFF
--- a/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
+++ b/src/main/java/uniqram/c1one/auth/dto/SignupRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uniqram.c1one.user.entity.Role;
 
 @Getter
 @NoArgsConstructor
@@ -27,14 +26,11 @@ public class SignupRequest {
     @Email
     private String email;
 
-    private Role role;
-
     @Builder
-    public SignupRequest(String username, String password, String confirmPassword, String email, Role role) {
+    public SignupRequest(String username, String password, String confirmPassword, String email) {
         this.username = username;
         this.password = password;
         this.confirmPassword = confirmPassword;
         this.email = email;
-        this.role = role;
     }
 }

--- a/src/main/java/uniqram/c1one/auth/service/AuthService.java
+++ b/src/main/java/uniqram/c1one/auth/service/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        Role role = request.getRole() != null ? request.getRole() : Role.USER;
+        Role role = Role.USER;
 
         Users user = new Users(
                 request.getUsername(),


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
회원가입 요청 DTO에서 role 필드를 제거하여, 사용자가 직접 권한을 조작하지 못하도록 리팩토링했습니다.
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- SignupRequest에서 role 필드 제거
- 생성자 및 @Builder 수정
- AuthService에서 무조건 Role.USER 지정


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #67 
<!--- closes #이슈번호 ex) closes #123 -->

