### PR TITLE
[Feat]  북마크 한 게시글 조회 기능 구현

### DIFF
--- a/src/main/java/uniqram/c1one/post/controller/BookmarkController.java
+++ b/src/main/java/uniqram/c1one/post/controller/BookmarkController.java
@@ -3,14 +3,14 @@ package uniqram.c1one.post.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.global.success.SuccessResponse;
+import uniqram.c1one.post.dto.BookmarkPostResponse;
 import uniqram.c1one.post.dto.BookmarkRequest;
 import uniqram.c1one.post.exception.BookmarkSuccessCode;
 import uniqram.c1one.post.service.BookmarkService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/bookmarks")
@@ -25,5 +25,13 @@ public class BookmarkController {
     ) {
         boolean isBookmarked = bookmarkService.bookmark(bookmarkRequest.getUserId(), bookmarkRequest.getPostId());
         return ResponseEntity.ok(SuccessResponse.of(BookmarkSuccessCode.BOOKMARK_TOGGLED, isBookmarked));
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<BookmarkPostResponse>>> getMyBookmarks(
+            @RequestParam Long userId
+    ) {
+        List<BookmarkPostResponse> bookmarks = bookmarkService.getMyBookmarks(userId);
+        return ResponseEntity.ok(SuccessResponse.of(BookmarkSuccessCode.BOOKMARK_LIST_LOADED, bookmarks));
     }
 }

--- a/src/main/java/uniqram/c1one/post/dto/BookmarkPostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/BookmarkPostResponse.java
@@ -1,0 +1,19 @@
+package uniqram.c1one.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookmarkPostResponse {
+
+    private Long postId;
+    private String representativeImageUrl;
+
+    public static BookmarkPostResponse of(Long postId, String representativeImageUrl) {
+        return BookmarkPostResponse.builder()
+                .postId(postId)
+                .representativeImageUrl(representativeImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/post/exception/BookmarkSuccessCode.java
+++ b/src/main/java/uniqram/c1one/post/exception/BookmarkSuccessCode.java
@@ -8,7 +8,8 @@ import uniqram.c1one.global.success.SuccessCode;
 @Getter
 @RequiredArgsConstructor
 public enum BookmarkSuccessCode implements SuccessCode {
-    BOOKMARK_TOGGLED(HttpStatus.CREATED, "북마크 상태가 변경되었습니다.");
+    BOOKMARK_TOGGLED(HttpStatus.CREATED, "북마크 상태가 변경되었습니다."),
+    BOOKMARK_LIST_LOADED(HttpStatus.OK, "북마크한 게시물을 성공적으로 조회했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/uniqram/c1one/post/repository/BookmarkRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/BookmarkRepository.java
@@ -4,10 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.Bookmark;
 
+import java.util.List;
+
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByUserIdAndPostId(Long userId, Long postId);
 
     void deleteByUserIdAndPostId(Long userId, Long postId);
+
+    List<Bookmark> findByUserId(Long userId);
 }

--- a/src/main/java/uniqram/c1one/post/service/BookmarkService.java
+++ b/src/main/java/uniqram/c1one/post/service/BookmarkService.java
@@ -3,12 +3,16 @@ package uniqram.c1one.post.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.post.dto.BookmarkPostResponse;
 import uniqram.c1one.post.entity.Bookmark;
 import uniqram.c1one.post.entity.Post;
 import uniqram.c1one.post.exception.PostErrorCode;
 import uniqram.c1one.post.exception.PostException;
 import uniqram.c1one.post.repository.BookmarkRepository;
+import uniqram.c1one.post.repository.PostMediaRepository;
 import uniqram.c1one.post.repository.PostRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
     private final PostRepository postRepository;
+    private final PostMediaRepository postMediaRepository;
 
     @Transactional
     public boolean bookmark(Long userId, Long postId) {
@@ -31,5 +36,20 @@ public class BookmarkService {
             bookmarkRepository.save(bookmark);
             return true; // 등록
         }
+    }
+
+    @Transactional(readOnly = true) // TODO: 북마크와 게시글(Post) 간 N+1 문제
+    public List<BookmarkPostResponse> getMyBookmarks(Long userId) {
+        List<Bookmark> bookmarks = bookmarkRepository.findByUserId(userId);
+
+        return bookmarks.stream()
+                .map(bookmark -> {
+                    Post post = bookmark.getPost();
+                    String repImageUrl = postMediaRepository.findFirstByPostIdOrderByIdAsc(post.getId())
+                            .orElseThrow(() -> new IllegalStateException("대표 이미지가 존재하지 않습니다."))
+                            .getMediaUrl();
+                    return BookmarkPostResponse.of(post.getId(), repImageUrl);
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
북마크한 게시글 목록 조회 기능 구현 (대표 이미지만 반환)


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 북마크한 게시글 목록을 조회하는 API 추가

- 게시글의 대표 이미지 URL만 반환하는 DTO 설계 및 적용

- 대표 이미지 조회 시 PostMedia를 통해 첫 번째 이미지만 반환


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 현재 Post와 Bookmark 간 N+1 쿼리 우려가 있어 추후 최적화 예정입니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


--------

closes #30 

