### PR TITLE
[Feat] Admin 회원가입 API 추가

### DIFF
--- a/src/main/java/uniqram/c1one/auth/controller/AdminAuthController.java
+++ b/src/main/java/uniqram/c1one/auth/controller/AdminAuthController.java
@@ -1,0 +1,23 @@
+package uniqram.c1one.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uniqram.c1one.auth.dto.SignupRequest;
+import uniqram.c1one.auth.service.AuthService;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminAuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signupAdmin(@Valid @RequestBody SignupRequest request) {
+        authService.signupAdmin(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("관리자 계정 생성 완료");
+    }
+}

--- a/src/main/java/uniqram/c1one/auth/service/AuthService.java
+++ b/src/main/java/uniqram/c1one/auth/service/AuthService.java
@@ -27,18 +27,26 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public void signup(SignupRequest request) {
-        if (!request.getPassword().equals(request.getConfirmPassword())) {
-            throw new AuthException(AuthErrorCode.PASSWORD_MISMATCH);
+        // 기존 회원가입
+        public void signup(SignupRequest request) {
+            validateAndSave(request, Role.USER);  // USER 역할로 고정
         }
 
-        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
-            throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
+        // 추가된 관리자 회원가입
+        public void signupAdmin(SignupRequest request) {
+            validateAndSave(request, Role.ADMIN);  // ADMIN 역할로 고정
         }
 
+        // 공통 회원 저장 로직
+        private void validateAndSave(SignupRequest request, Role role) {
+            if (!request.getPassword().equals(request.getConfirmPassword())) {
+                throw new AuthException(AuthErrorCode.PASSWORD_MISMATCH);
+            }
+
+            if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+                throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
+            }
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-
-        Role role = Role.USER;
 
         Users user = Users.builder()
                 .username(request.getUsername())
@@ -64,6 +72,4 @@ public class AuthService {
         return jwtTokenProvider.generateToken(auth);
 
     }
-
-
-    }
+}

--- a/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/**"
+                                "/**" // 개발 끝나면 삭제 예정.
                         ).permitAll()
                         .requestMatchers("/api/user/**").hasRole("USER")
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
운영자(Admin) 계정 생성을 위한 API를 기존 Auth 도메인 내부에 구현했습니다.

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 관리자 회원가입 API (` /api/admin/signup`) 구현
- AuthService 내 signupAdmin 로직 분리
- AdminAuthController 추가 및 도메인 내 분리 구성

## 📸 스크린샷 (선택)
![스크린샷 2025-06-26 114421](https://github.com/user-attachments/assets/eb2481fb-826b-4f38-9add-4c8145bf242f)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #68 
<!--- closes #이슈번호 ex) closes #123 -->

