### PR TITLE
[Feat][Fix] toggle 방식의 댓글/게시물 좋아요 기능 개발 및 테스트 코드 추가

### DIFF
--- a/src/main/java/uniqram/c1one/comment/controller/CommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/CommentController.java
@@ -1,13 +1,14 @@
 package uniqram.c1one.comment.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.comment.dto.CommentCreateRequest;
+import uniqram.c1one.comment.dto.CommentLikeResponse;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.comment.dto.CommentUpdateRequest;
 import uniqram.c1one.comment.exception.CommentSuccessCode;
+import uniqram.c1one.comment.service.CommentLikeService;
 import uniqram.c1one.comment.service.CommentService;
 import uniqram.c1one.global.success.SuccessResponse;
 
@@ -18,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CommentController {
     private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
@@ -51,4 +53,12 @@ public class CommentController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/{commentId}/like")
+    public ResponseEntity<CommentLikeResponse> likeComment(
+            @PathVariable Long commentId,
+            @RequestParam Long userId
+    ){
+        CommentLikeResponse like = commentLikeService.likeComment(userId, commentId);
+        return ResponseEntity.ok(like);
+    }
 }

--- a/src/main/java/uniqram/c1one/comment/dto/CommentLikeResponse.java
+++ b/src/main/java/uniqram/c1one/comment/dto/CommentLikeResponse.java
@@ -1,0 +1,14 @@
+package uniqram.c1one.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentLikeResponse {
+    private Long commentId;
+    private boolean liked;
+    private int likeCount;
+}

--- a/src/main/java/uniqram/c1one/comment/dto/CommentResponse.java
+++ b/src/main/java/uniqram/c1one/comment/dto/CommentResponse.java
@@ -12,6 +12,7 @@ public class CommentResponse {
     private Long userId;
     private String userName;
     private String content;
+    private int likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private Long parentCommentId;

--- a/src/main/java/uniqram/c1one/comment/entity/Comment.java
+++ b/src/main/java/uniqram/c1one/comment/entity/Comment.java
@@ -51,11 +51,5 @@ public class Comment extends BaseEntity {
         this.content = content;
     }
 
-    public void increaseLikesCount() {
-        this.likeCount = likeCount + 1;
-    }
-    public void decreaseLikesCount() {
-        this.likeCount = likeCount - 1;
-    }
 
 }

--- a/src/main/java/uniqram/c1one/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentLikeRepository.java
@@ -5,6 +5,10 @@ import uniqram.c1one.comment.entity.Comment;
 import uniqram.c1one.comment.entity.CommentLike;
 import uniqram.c1one.user.entity.Users;
 
+import java.util.Optional;
+
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    int countByComment(Comment comment);
     boolean existsByUserAndComment(Users user, Comment comment);
+    Optional<CommentLike> findByUserAndComment(Users user, Comment comment);
 }

--- a/src/main/java/uniqram/c1one/comment/service/CommentLikeService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentLikeService.java
@@ -1,0 +1,54 @@
+package uniqram.c1one.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.comment.dto.CommentLikeResponse;
+import uniqram.c1one.comment.entity.Comment;
+import uniqram.c1one.comment.entity.CommentLike;
+import uniqram.c1one.comment.exception.CommentErrorCode;
+import uniqram.c1one.comment.exception.CommentException;
+import uniqram.c1one.comment.repository.CommentLikeRepository;
+import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentLikeResponse likeComment(Long userId, Long commentId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.USER_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        Optional<CommentLike> existing = commentLikeRepository.findByUserAndComment(user, comment);
+
+        boolean liked;
+        if (existing.isPresent()) {
+            commentLikeRepository.delete(existing.get());
+            liked = false;
+        } else {
+            CommentLike commentLike = CommentLike.builder().user(user).comment(comment).build();
+            commentLikeRepository.save(commentLike);
+            liked = true;
+        }
+
+        int likeCount = commentLikeRepository.countByComment(comment);
+
+        return CommentLikeResponse.builder()
+                .commentId(commentId)
+                .liked(liked)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.global.success.SuccessResponse;
 import uniqram.c1one.post.dto.*;
 import uniqram.c1one.post.exception.PostSuccessCode;
+import uniqram.c1one.post.service.PostLikeService;
 import uniqram.c1one.post.service.PostService;
 
 @RestController
@@ -16,6 +17,7 @@ import uniqram.c1one.post.service.PostService;
 public class PostController {
 
     private final PostService postService;
+    private final PostLikeService postLikeService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<PostResponse>> createPost(
@@ -63,5 +65,14 @@ public class PostController {
     ) {
         postService.deletePost(userId, postId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{postId}/like")
+    public ResponseEntity<PostLikeResponse> likePost(
+            @PathVariable Long postId,
+            @RequestParam Long userId
+    ){
+        PostLikeResponse like = postLikeService.like(userId, postId);
+        return ResponseEntity.ok(like);
     }
 }

--- a/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
@@ -22,13 +22,13 @@ public class HomePostResponse {
     private int likeCount;
     private int commentCount;
 
-    public static HomePostResponse from(Post post, List<String> mediaUrl) {
+    public static HomePostResponse from(Post post, List<String> mediaUrl, int likeCount) {
         return HomePostResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .location(post.getLocation())
                 .mediaUrls(mediaUrl)
-                .likeCount(post.getLikeCount())
+                .likeCount(likeCount)
                 .commentCount(post.getCommentCount())
                 .memberId(post.getUser().getId())
                 .nickname(post.getUser().getUsername())

--- a/src/main/java/uniqram/c1one/post/dto/PostLikeResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/PostLikeResponse.java
@@ -1,0 +1,14 @@
+package uniqram.c1one.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PostLikeResponse {
+    private Long postId;
+    private boolean liked;
+    private int likeCount;
+}

--- a/src/main/java/uniqram/c1one/post/entity/Post.java
+++ b/src/main/java/uniqram/c1one/post/entity/Post.java
@@ -54,13 +54,6 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    public void increaseLikesCount() {
-        this.likeCount = likeCount + 1;
-    }
-    public void decreaseLikesCount() {
-        this.likeCount = likeCount - 1;
-    }
-
     public void update(String content, String location) {
         this.content = content;
         this.location = location;

--- a/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
@@ -1,0 +1,16 @@
+package uniqram.c1one.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uniqram.c1one.post.entity.Post;
+import uniqram.c1one.post.entity.PostLike;
+import uniqram.c1one.user.entity.Users;
+
+import java.util.Optional;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    int countByPost(Post post);
+    boolean existsByUserAndPost(Users user, Post post);
+    Optional<PostLike> findByUserAndPost(Users user, Post post);
+}

--- a/src/main/java/uniqram/c1one/post/service/PostLikeService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostLikeService.java
@@ -1,0 +1,54 @@
+package uniqram.c1one.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.post.dto.PostLikeResponse;
+import uniqram.c1one.post.entity.Post;
+import uniqram.c1one.post.entity.PostLike;
+import uniqram.c1one.post.exception.PostErrorCode;
+import uniqram.c1one.post.exception.PostException;
+import uniqram.c1one.post.repository.PostLikeRepository;
+import uniqram.c1one.post.repository.PostRepository;
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PostLikeResponse like(Long userId, Long postId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        Optional<PostLike> existing = postLikeRepository.findByUserAndPost(user, post);
+
+        boolean liked;
+        if (existing.isPresent()) {
+            postLikeRepository.delete(existing.get());
+            liked = false;
+        } else {
+            PostLike postLike = PostLike.builder()
+                    .user(user)
+                    .post(post)
+                    .build();
+            postLikeRepository.save(postLike);
+            liked = true;
+        }
+        int likeCount = postLikeRepository.countByPost(post);
+
+        return PostLikeResponse.builder()
+                .postId(postId)
+                .liked(liked)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/post/service/PostService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostService.java
@@ -12,6 +12,7 @@ import uniqram.c1one.post.entity.Post;
 import uniqram.c1one.post.entity.PostMedia;
 import uniqram.c1one.post.exception.PostErrorCode;
 import uniqram.c1one.post.exception.PostException;
+import uniqram.c1one.post.repository.PostLikeRepository;
 import uniqram.c1one.post.repository.PostMediaRepository;
 import uniqram.c1one.post.repository.PostRepository;
 import uniqram.c1one.user.entity.Users;
@@ -27,6 +28,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final PostMediaRepository postMediaRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public PostResponse createPost(Long userId, PostCreateRequest postCreateRequest) {
@@ -68,8 +70,8 @@ public class PostService {
                     .stream()
                     .map(PostMedia::getMediaUrl)
                     .collect(Collectors.toList());
-
-            return HomePostResponse.from(post, mediaUrls);
+            int likeCount = postLikeRepository.countByPost(post);
+            return HomePostResponse.from(post, mediaUrls, likeCount);
         });
     }
 

--- a/src/test/java/uniqram/c1one/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/uniqram/c1one/comment/service/CommentLikeServiceTest.java
@@ -1,0 +1,97 @@
+package uniqram.c1one.comment.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uniqram.c1one.comment.dto.CommentLikeResponse;
+import uniqram.c1one.comment.entity.Comment;
+import uniqram.c1one.comment.entity.CommentLike;
+import uniqram.c1one.comment.repository.CommentLikeRepository;
+import uniqram.c1one.comment.repository.CommentRepository;
+
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommentLikeServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @InjectMocks
+    private CommentLikeService commentLikeService;
+
+    @Test
+    void commentLike() {
+
+        //given
+        Long userId = 1L;
+        Long commentId = 2L;
+
+        Users user = Users.builder().id(userId).username("tester").build();
+        Comment comment = Comment.builder().id(commentId).user(user).content("test01").build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(commentLikeRepository.findByUserAndComment(user, comment)).willReturn(Optional.empty());
+        given(commentLikeRepository.countByComment(comment)).willReturn(1);
+
+        //when
+        CommentLikeResponse likeResponse = commentLikeService.likeComment(userId, commentId);
+
+        //then
+        assertThat(likeResponse.isLiked()).isTrue();
+        assertThat(likeResponse.getCommentId()).isEqualTo(commentId);
+        assertThat(likeResponse.getLikeCount()).isEqualTo(1);
+
+        //save가 1번 호출되는가
+        then(commentLikeRepository).should(times(1)).save(any(CommentLike.class));
+    }
+
+    @Test
+    void commentNotLike() {
+
+        //given
+        Long userId = 1L;
+        Long commentId = 2L;
+
+        Users user = Users.builder().id(userId).username("tester").build();
+        Comment comment = Comment.builder().id(commentId).user(user).content("test02").build();
+        CommentLike existingLike = CommentLike.builder().user(user).comment(comment).build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(commentLikeRepository.findByUserAndComment(user, comment)).willReturn(Optional.of(existingLike));
+        given(commentLikeRepository.countByComment(comment)).willReturn(0);
+
+        //when
+        CommentLikeResponse likeResponse = commentLikeService.likeComment(userId, commentId);
+
+        //then
+        assertThat(likeResponse.isLiked()).isFalse();
+        assertThat(likeResponse.getCommentId()).isEqualTo(commentId);
+        assertThat(likeResponse.getLikeCount()).isEqualTo(0);
+
+        //delete가 1번 호출되는가
+        then(commentLikeRepository).should(times(1)).delete(existingLike);
+    }
+
+
+
+}

--- a/src/test/java/uniqram/c1one/comment/service/CommentServiceTest.java
+++ b/src/test/java/uniqram/c1one/comment/service/CommentServiceTest.java
@@ -1,0 +1,63 @@
+package uniqram.c1one.comment.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import uniqram.c1one.comment.dto.CommentCreateRequest;
+import uniqram.c1one.comment.dto.CommentResponse;
+import uniqram.c1one.comment.entity.Comment;
+import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.post.entity.Post;
+import uniqram.c1one.post.repository.PostRepository;
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+//    @Test
+//    void createComment() {
+//        //given
+//        Long userId = 1L;
+//        Long postId = 2L;
+//        String content = "This is a comment";
+//        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(userId, postId, null, content);
+//
+//        Users user = Users.builder().id(userId).username("tested").build();
+//        Post post = Post.builder().id(postId).content("test post").user(user).build();
+//        Comment comment = Comment.builder().id(10L).user(user).post(post).content(content).build();
+//
+//        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+//        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+//        given(commentRepository.save(any(Comment.class))).willReturn(comment);
+//
+//        CommentResponse response = commentService.createComment(userId, commentCreateRequest);
+//
+//        assertThat(response.getCommentId()).isEqualTo(10L);
+//        assertThat(response.getUserId()).isEqualTo(userId);
+//        assertThat(response.getContent()).isEqualTo(content);
+//        assertThat(response.getParentCommentId()).isNull();
+//    }
+
+}


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
toggle 방식의 댓글/게시물 좋아요 기능 개발

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- CommentLikeRepository, PostLikeRepository 개발
- CommentLikeResponse, PostLikeResponse 개발
- CommentLikeService, PostLikeService에서 toggle 방식의 좋아요 기능 개발(이미 좋아요 한 댓글 or 게시물에 한 번 더 좋아요를 하면 취소되는 방식)
- 해당하는 Controller에서 Post Mapping을 통한 호출 

## ⛔️ 버그 해결
- 댓글/게시물 전체 조회 시 좋아요의 증감 처리가 적용되지 않아, likeCount가 0으로 나오는 에러 발생
- 해당 서비스의 조회 기능에서 likeCount만 commentLikeRepository에서 가져오는 것으로 변경

## 📸 스크린샷 (선택)
![스크린샷 2025-06-27 오후 3 47 48](https://github.com/user-attachments/assets/1444dfb5-299f-4f22-b845-a93f3e2ff69b)
![스크린샷 2025-06-27 오후 3 47 57](https://github.com/user-attachments/assets/a73c9ee7-767a-4208-894a-e33a1919db04)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
@ynyejin 
Post 도메인의 dto 패키지 내에 HomePostResponse의 from() 메소드의 매개변수를 from(Post post, List<String> mediaUrl)에서
from(Post post, List<String> mediaUrl, int likeCount) 로의 변경과,
PostService에서 getHomePosts의 메소드에서 
int likeCount = postLikeRepository.countByPost(post); 가 추가되었습니다.

괜찮으신지 피드백 부탁드립니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
#81 
#86 
<!--- closes #이슈번호 ex) closes #123 -->

