### PR TITLE
[Refactor] CommentService의 orElseThrow() 구문 변경

### DIFF
--- a/src/main/java/uniqram/c1one/comment/exception/CommentErrorCode.java
+++ b/src/main/java/uniqram/c1one/comment/exception/CommentErrorCode.java
@@ -12,7 +12,9 @@ public enum CommentErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "댓글은 필수 입력 값입니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
-    NO_AUTHORITY(HttpStatus.FORBIDDEN, "수정 또는 삭제 권한이 없습니다.");
+    NO_AUTHORITY(HttpStatus.FORBIDDEN, "수정 또는 삭제 권한이 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 댓글을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/uniqram/c1one/comment/service/CommentService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentService.java
@@ -30,10 +30,10 @@ public class CommentService {
 
     public CommentResponse createComment(Long userId, CommentCreateRequest createRequest) {
         Users users = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new CommentException(CommentErrorCode.USER_NOT_FOUND));
 
         Post post = postRepository.findById(createRequest.getPostId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new CommentException(CommentErrorCode.POST_NOT_FOUND));
 
         Comment.CommentBuilder commentBuilder = Comment.builder()
                 .user(users)
@@ -42,7 +42,7 @@ public class CommentService {
 
         if (createRequest.getParentCommentId() != null) {
             Comment parent = commentRepository.findById(createRequest.getParentCommentId())
-                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다."));
+                    .orElseThrow(() -> new CommentException(CommentErrorCode.PARENT_COMMENT_NOT_FOUND));
             commentBuilder.parentComment(parent);
         }
 
@@ -63,7 +63,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentResponse> getComments(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new CommentException(CommentErrorCode.POST_NOT_FOUND));
 
         List<Comment> comments = commentRepository.findByPost(post);
 


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
CommentService의 orElseThrow() 구문 변경

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- orElseThrow()의 IllegalArgumentException을 CommentException으로 통합하여 관리
- 세부적인 예외사항은 Enum 타입의 에러코드 및 메세지 반환
-


## 📸 스크린샷 (선택)
![스크린샷 2025-06-28 오후 3 47 56](https://github.com/user-attachments/assets/4fe75125-a5be-440d-ad95-ce827c72ba60)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
#89 
<!--- closes #이슈번호 ex) closes #123 -->

