### PR TITLE
[Refactor] 홈 화면 조회 API N+1 문제 개선

### DIFF
--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -29,12 +29,13 @@ public class PostController {
                 .body(SuccessResponse.of(PostSuccessCode.POST_CREATED, postResponse));
     }
 
-    @GetMapping("/home")
+    @GetMapping("/home/{userId}")
     public ResponseEntity<Page<HomePostResponse>> getHomePosts(
+            @PathVariable Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        Page<HomePostResponse> homePosts = postService.getHomePosts(page, size);
+        Page<HomePostResponse> homePosts = postService.getHomePosts(userId, page, size);
         return ResponseEntity.ok(homePosts);
     }
 

--- a/src/main/java/uniqram/c1one/post/dto/CommentCountDto.java
+++ b/src/main/java/uniqram/c1one/post/dto/CommentCountDto.java
@@ -1,0 +1,12 @@
+package uniqram.c1one.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCountDto {
+
+    private Long postId;
+    private Long count;
+}

--- a/src/main/java/uniqram/c1one/post/dto/CommentDto.java
+++ b/src/main/java/uniqram/c1one/post/dto/CommentDto.java
@@ -1,0 +1,17 @@
+package uniqram.c1one.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentDto {
+
+    private Long postId;
+    private Long commentId;
+    private String username;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/HomePostResponse.java
@@ -17,21 +17,32 @@ public class HomePostResponse {
     private List<String> mediaUrls;
 
     private Long memberId;
-    private String nickname;
+    private String username;
 
     private int likeCount;
-    private int commentCount;
+    private List<LikeUserDto> likeUsers;
+    private boolean likedByMe;
 
-    public static HomePostResponse from(Post post, List<String> mediaUrl, int likeCount) {
+    private int commentCount;
+    private List<CommentDto> comments;
+
+    public static HomePostResponse from(Post post,
+                                        List<String> mediaUrl,
+                                        int likeCount,
+                                        List<LikeUserDto> likeUsers,
+                                        boolean likedByMe) {
         return HomePostResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .location(post.getLocation())
                 .mediaUrls(mediaUrl)
                 .likeCount(likeCount)
-                .commentCount(post.getCommentCount())
+                .likeUsers(likeUsers)
+                .likedByMe(likedByMe)
+//                .commentCount(commentCount)
+//                .comments(comments)
                 .memberId(post.getUser().getId())
-                .nickname(post.getUser().getUsername())
+                .username(post.getUser().getUsername())
                 .build();
     }
 }

--- a/src/main/java/uniqram/c1one/post/dto/LikeCountDto.java
+++ b/src/main/java/uniqram/c1one/post/dto/LikeCountDto.java
@@ -1,0 +1,12 @@
+package uniqram.c1one.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeCountDto {
+
+    private Long postId;
+    private Long count;
+}

--- a/src/main/java/uniqram/c1one/post/dto/LikeUserDto.java
+++ b/src/main/java/uniqram/c1one/post/dto/LikeUserDto.java
@@ -1,0 +1,13 @@
+package uniqram.c1one.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeUserDto {
+
+    private Long postId;
+    private Long userId;
+    private String username;
+}

--- a/src/main/java/uniqram/c1one/post/dto/PostResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/PostResponse.java
@@ -20,7 +20,7 @@ public class PostResponse {
     private int commentCount;
 
     private Long memberId;
-    private String nickname;
+    private String username;
 
     public static PostResponse from(Post post, List<String> mediaUrl) {
         return PostResponse.builder()
@@ -31,7 +31,7 @@ public class PostResponse {
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
                 .memberId(post.getUser().getId())
-                .nickname(post.getUser().getUsername())
+                .username(post.getUser().getUsername())
                 .build();
     }
 }

--- a/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
@@ -1,11 +1,16 @@
 package uniqram.c1one.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import uniqram.c1one.post.dto.LikeCountDto;
+import uniqram.c1one.post.dto.LikeUserDto;
 import uniqram.c1one.post.entity.Post;
 import uniqram.c1one.post.entity.PostLike;
 import uniqram.c1one.user.entity.Users;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +18,15 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     int countByPost(Post post);
     boolean existsByUserAndPost(Users user, Post post);
     Optional<PostLike> findByUserAndPost(Users user, Post post);
+
+    @Query("SELECT new uniqram.c1one.post.dto.LikeCountDto(pl.post.id, COUNT(pl)) " +
+            "FROM PostLike pl WHERE pl.post.id IN :postIds GROUP BY pl.post.id")
+    List<LikeCountDto> countByPostIds(@Param("postIds") List<Long> postIds);
+
+    @Query("SELECT new uniqram.c1one.post.dto.LikeUserDto(pl.post.id, pl.user.id, pl.user.username) " +
+            "FROM PostLike pl WHERE pl.post.id IN :postIds")
+    List<LikeUserDto> findLikeUsersByPostIds(@Param("postIds") List<Long> postIds);
+
+    @Query("SELECT pl.post.id FROM PostLike pl WHERE pl.post.id IN :postIds AND pl.user.id = :userId")
+    List<Long> findPostIdsLikedByUser(@Param("postIds") List<Long> postIds, @Param("userId") Long userId);
 }

--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -14,4 +14,6 @@ public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
     Optional<PostMedia> findFirstByPostIdOrderByIdAsc(@Param("postId") Long postId);
 
     List<PostMedia> findByPostIdOrderByIdAsc(Long postId);
+
+    List<PostMedia> findByPostIdIn(List<Long> postIds);
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
홈 화면 게시글 조회 API에서 발생하던 N+1 문제를 개선했습니다.


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 게시글 미디어 데이터를 IN 쿼리로 한 번에 조회
- 좋아요 수, 좋아요 누른 사람 목록, 로그인 유저의 좋아요 여부 일괄 조회 로직 추가
- HomePostResponse 필드 확장 및 응답 데이터 개선


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 댓글 목록 및 댓글 수 관련 로직은 주석 처리 상태입니다. 추후 주석 해제 예정입니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


---------

closes #29 