### PR TITLE
[Feat] 단일 게시물 상세 조회 API 구현

### DIFF
--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -49,6 +49,15 @@ public class PostController {
         return ResponseEntity.ok(posts);
     }
 
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(
+            @PathVariable Long postId,
+            @RequestParam Long userId
+    ) {
+        PostDetailResponse postDetailResponse = postService.getPostDetail(userId, postId);
+        return ResponseEntity.ok(postDetailResponse);
+    }
+
     @PatchMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(
             @PathVariable Long postId,

--- a/src/main/java/uniqram/c1one/post/dto/PostDetailResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/PostDetailResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class HomePostResponse {
+public class PostDetailResponse {
 
     private Long postId;
     private String content;
@@ -24,12 +24,12 @@ public class HomePostResponse {
     private int commentCount;
     private List<CommentDto> comments;
 
-    public static HomePostResponse from(Post post,
+    public static PostDetailResponse from(Post post,
                                         List<String> mediaUrl,
                                         int likeCount,
                                         List<LikeUserDto> likeUsers,
                                         boolean likedByMe) {
-        return HomePostResponse.builder()
+        return PostDetailResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
                 .location(post.getLocation())

--- a/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
@@ -27,6 +27,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
             "FROM PostLike pl WHERE pl.post.id IN :postIds")
     List<LikeUserDto> findLikeUsersByPostIds(@Param("postIds") List<Long> postIds);
 
+    @Query("SELECT new uniqram.c1one.post.dto.LikeUserDto(pl.post.id, pl.user.id, pl.user.username) " +
+            "FROM PostLike pl WHERE pl.post.id = :postId")
+    List<LikeUserDto> findLikeUsersByPostId(@Param("postId") Long postId);
+
     @Query("SELECT pl.post.id FROM PostLike pl WHERE pl.post.id IN :postIds AND pl.user.id = :userId")
     List<Long> findPostIdsLikedByUser(@Param("postIds") List<Long> postIds, @Param("userId") Long userId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -1,6 +1,7 @@
 package uniqram.c1one.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.PostMedia;
@@ -11,9 +12,23 @@ import java.util.Optional;
 @Repository
 public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
 
+    // 특정 게시물 1개의 첫번째 이미지
     Optional<PostMedia> findFirstByPostIdOrderByIdAsc(@Param("postId") Long postId);
 
+    // 특정 게시물의 전체 이미지
     List<PostMedia> findByPostIdOrderByIdAsc(Long postId);
 
+    // 여러 게시물의 전체 이미지
     List<PostMedia> findByPostIdIn(List<Long> postIds);
+
+    // 여러 게시물의 첫번째 이미지
+    @Query(value = "SELECT pm.* " +
+            "FROM post_media pm " +
+            "INNER JOIN ( " +
+            "   SELECT post_id, MIN(id) AS min_id " +
+            "   FROM post_media " +
+            "   WHERE post_id IN :postIds " +
+            "   GROUP BY post_id " +
+            ") first_pm ON pm.id = first_pm.min_id", nativeQuery = true)
+    List<PostMedia> findFirstImagesByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/uniqram/c1one/post/service/PostService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostService.java
@@ -130,6 +130,29 @@ public class PostService {
     }
 
     @Transactional
+    public PostDetailResponse getPostDetail(Long userId, Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        List<String> mediaUrls = postMediaRepository.findByPostIdOrderByIdAsc(postId)
+                .stream().map(PostMedia::getMediaUrl)
+                .toList();
+
+        int likeCount = postLikeRepository.countByPost(post);
+
+        List<LikeUserDto> likeUsers = postLikeRepository.findLikeUsersByPostId(postId);
+
+        boolean likedByMe = postLikeRepository.existsByPostIdAndUserId(postId, userId);
+
+//        int commentCount = commentRepository.countByPostId(postId);
+
+//        List<CommentDto> comments = commentRepository.findCommentsByPostId(postId);
+
+        return PostDetailResponse.from(post, mediaUrls, likeCount, likeUsers, likedByMe);
+    }
+
+    @Transactional
     public PostResponse updatePost(Long userId, Long postId, PostUpdateRequest postUpdateRequest) {
 
         Post post = postRepository.findById(postId)


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
단일 게시물 상세 조회 API를 구현했습니다.


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 게시물 단건 조회 API 컨트롤러 추가
- 전체 이미지, 좋아요 수, 좋아요 누른 사람 목록, 로그인 유저의 좋아요 여부 반환
- 댓글 목록 포함하여 상세 정보 응답
- PostDetailResponse DTO 작성


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 추후 테스트 코드 작성 예정입니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


----------


closes #25 

