### PR TITLE
[Refactor] 특정 사용자 게시물 조회 API N+1 문제 개선

### DIFF
--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -1,6 +1,7 @@
 package uniqram.c1one.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.PostMedia;
@@ -11,9 +12,23 @@ import java.util.Optional;
 @Repository
 public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
 
+    // 특정 게시물 1개의 첫번째 이미지
     Optional<PostMedia> findFirstByPostIdOrderByIdAsc(@Param("postId") Long postId);
 
+    // 특정 게시물의 전체 이미지
     List<PostMedia> findByPostIdOrderByIdAsc(Long postId);
 
+    // 여러 게시물의 전체 이미지
     List<PostMedia> findByPostIdIn(List<Long> postIds);
+
+    // 여러 게시물의 첫번째 이미지
+    @Query(value = "SELECT pm.* " +
+            "FROM post_media pm " +
+            "INNER JOIN ( " +
+            "   SELECT post_id, MIN(id) AS min_id " +
+            "   FROM post_media " +
+            "   WHERE post_id IN :postIds " +
+            "   GROUP BY post_id " +
+            ") first_pm ON pm.id = first_pm.min_id", nativeQuery = true)
+    List<PostMedia> findFirstImagesByPostIds(@Param("postIds") List<Long> postIds);
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
특정 사용자 게시물 조회 API의 대표 이미지 조회 로직을 개선하여 N+1 문제를 해결했습니다.


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- PostMediaRepository에 게시물 대표 이미지 쿼리 메서드 추가
- 서비스 로직 내 반복 쿼리 제거 및 Map 구조로 최적화
- 기존 로직 유지하면서 쿼리 효율 개선


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 추후 테스트 코드 작성 예정입니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


------------


closes #94 

