### PR TITLE
[Refactor] CommentController 분리

### DIFF
--- a/src/main/java/uniqram/c1one/comment/controller/CommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/CommentController.java
@@ -21,20 +21,6 @@ public class CommentController {
     private final CommentService commentService;
     private final CommentLikeService commentLikeService;
 
-    @PostMapping
-    public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
-            @RequestBody CommentCreateRequest commentCreateRequest){
-        Long userId = commentCreateRequest.getUserId();
-        CommentResponse response = commentService.createComment(userId, commentCreateRequest);
-        return ResponseEntity.status(CommentSuccessCode.COMMENT_CREATED.getStatus())
-                .body(SuccessResponse.of(CommentSuccessCode.COMMENT_CREATED, response));
-    }
-
-    @GetMapping("/{postId}")
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getComments(postId));
-    }
-
     @PatchMapping("/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable Long commentId,

--- a/src/main/java/uniqram/c1one/comment/controller/CommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/CommentController.java
@@ -15,13 +15,13 @@ import uniqram.c1one.global.success.SuccessResponse;
 import java.util.List;
 
 @RestController
-@RequestMapping("/comments")
+@RequestMapping("/comments/{commentId}")
 @RequiredArgsConstructor
 public class CommentController {
     private final CommentService commentService;
     private final CommentLikeService commentLikeService;
 
-    @PatchMapping("/{commentId}")
+    @PatchMapping
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable Long commentId,
             @RequestParam Long userId,
@@ -31,7 +31,7 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{commentId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long commentId,
             @RequestParam Long userId) {
@@ -39,7 +39,7 @@ public class CommentController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{commentId}/like")
+    @PostMapping("/like")
     public ResponseEntity<CommentLikeResponse> likeComment(
             @PathVariable Long commentId,
             @RequestParam Long userId

--- a/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
@@ -1,0 +1,36 @@
+package uniqram.c1one.comment.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uniqram.c1one.comment.dto.CommentCreateRequest;
+import uniqram.c1one.comment.dto.CommentResponse;
+import uniqram.c1one.comment.exception.CommentSuccessCode;
+import uniqram.c1one.comment.service.CommentService;
+import uniqram.c1one.global.success.SuccessResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class PostCommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
+            @PathVariable Long postId,
+            @RequestBody CommentCreateRequest commentCreateRequest){
+        Long userId = commentCreateRequest.getUserId();
+        CommentResponse response = commentService.createComment(userId, postId,commentCreateRequest);
+        return ResponseEntity.status(CommentSuccessCode.COMMENT_CREATED.getStatus())
+                .body(SuccessResponse.of(CommentSuccessCode.COMMENT_CREATED, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(commentService.getComments(postId));
+    }
+
+}

--- a/src/main/java/uniqram/c1one/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/uniqram/c1one/comment/dto/CommentCreateRequest.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentCreateRequest {
     private Long userId; //임시 포함
-    private Long postId;
     private Long parentCommentId; //대댓글인 경우
     private String content;
 }

--- a/src/main/java/uniqram/c1one/comment/service/CommentService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentService.java
@@ -28,11 +28,11 @@ public class CommentService {
     private final UserRepository userRepository;
     private final CommentLikeRepository commentLikeRepository;
 
-    public CommentResponse createComment(Long userId, CommentCreateRequest createRequest) {
+    public CommentResponse createComment(Long userId, Long postId, CommentCreateRequest createRequest) {
         Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.USER_NOT_FOUND));
 
-        Post post = postRepository.findById(createRequest.getPostId())
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.POST_NOT_FOUND));
 
         Comment.CommentBuilder commentBuilder = Comment.builder()


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
PostCommentController 생성

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- CommentController와 PostCommentController의 분리
- PostCommentController는 댓글의 생성/조회에만 관여
- CommentController는 단일 리소스(수정, 삭제, 좋아요)에 관여
- CommentCreateRequest dto에서 postId를 삭제, PostCommentController에서 @PathVariable로 postId를 받아옴


## 📸 스크린샷 (선택)
![스크린샷 2025-06-30 오전 10 26 26](https://github.com/user-attachments/assets/07d9c2a5-2cb1-4919-a46d-bbaf143bdd74)

![스크린샷 2025-06-30 오전 10 26 53](https://github.com/user-attachments/assets/8a1bb0c2-02cb-497c-b422-fd3a29c0b107)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#90 
