### PR TITLE
[Feat] 로그인 성공 후 성공 페이지 접근

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// Thymeleaf 템플릿 엔진
-	implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
+	/*implementation "org.springframework.boot:spring-boot-starter-thymeleaf"*/
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/uniqram/c1one/auth/controller/AuthController.java
+++ b/src/main/java/uniqram/c1one/auth/controller/AuthController.java
@@ -16,6 +16,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -46,15 +49,23 @@ public class AuthController {
             Cookie accessTokenCookie = new Cookie("access_token", jwtToken.getAccessToken());
             accessTokenCookie.setHttpOnly(true);
             accessTokenCookie.setPath("/");
+            accessTokenCookie.setMaxAge(24 * 60 * 60); // 24시간
+
 
             Cookie refreshTokenCookie = new Cookie("refresh_token", jwtToken.getRefreshToken());
             refreshTokenCookie.setHttpOnly(true);
             refreshTokenCookie.setPath("/");
+            accessTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 7일
 
             response.addCookie(accessTokenCookie);
             response.addCookie(refreshTokenCookie);
 
-            return ResponseEntity.ok(jwtToken);
+            Map<String, Object> responseBody = new HashMap<>();
+            responseBody.put("accessToken", jwtToken.getAccessToken());
+            responseBody.put("message", "로그인 성공");
+            responseBody.put("redirectUrl", "/index");
+
+            return ResponseEntity.ok(responseBody);
 
         } catch (Exception e) {
             return ResponseEntity
@@ -83,4 +94,13 @@ public class AuthController {
     static class SimpleResponse {
         private String message;
     }
+
+    @Getter
+    @AllArgsConstructor
+    static class LoginResponse {
+        private String accessToken;
+        private String refreshToken;
+        private String redirectUrl;
+    }
+
 }

--- a/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
@@ -46,8 +46,7 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/css/**", "/js/**"  // 정적 리소스
+                                "/swagger-ui.html"
                         ).permitAll()
                         .requestMatchers("index.html","/index").authenticated()
                         .requestMatchers("/api/user/**").hasRole("USER")

--- a/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
@@ -46,8 +46,10 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html"
+                                "/swagger-ui.html",
+                                "/css/**", "/js/**"  // 정적 리소스
                         ).permitAll()
+                        .requestMatchers("index.html","/index").authenticated()
                         .requestMatchers("/api/user/**").hasRole("USER")
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -58,9 +60,13 @@ public class SecurityConfig {
                 .addFilterBefore(
                         jwtFilter,
                         UsernamePasswordAuthenticationFilter.class
+                )
+                // 예외 처리 추가
+                .exceptionHandling(handling -> handling
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendRedirect("/api/auth/signin");  // 로그인 페이지로 리다이렉트
+                        })
                 );
-
-
         return http.build();
     }
 

--- a/src/main/java/uniqram/c1one/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/uniqram/c1one/security/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package uniqram.c1one.security.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
+
+        // 쿠키에서 토큰 확인
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/src/main/java/uniqram/c1one/web/WebController.java
+++ b/src/main/java/uniqram/c1one/web/WebController.java
@@ -1,19 +1,20 @@
 package uniqram.c1one.web;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class WebController {
 
-    @GetMapping("/")
-    public String home() {
-        return "redirect:/api/auth/signin";
+    @GetMapping(value = {"/index", "/index.html"})
+    public String index(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails != null) {
+            return "index";  // 인증된 사용자인 경우
+        }
+        return "redirect:/api/auth/signin";  // 인증되지 않은 경우
     }
 
-    @GetMapping("/index")
-    public String index() {
-        return "index";
-    }
 
 }

--- a/src/main/resources/templates/signin.html
+++ b/src/main/resources/templates/signin.html
@@ -34,13 +34,14 @@
             headers: {
                 'Content-Type': 'application/json'
             },
+            credentials: 'include',  // 쿠키를 포함하도록 설정
             body: JSON.stringify(formData)
         })
             .then(response => {
                 if (response.ok) {
                     return response.json();
                 }
-                throw new Error('로그인 실패');
+                    throw new Error('로그인 실패');
             })
             .then(data => {
                 // 로그인 성공
@@ -48,6 +49,7 @@
             })
             .catch(error => {
                 // 에러 메시지 표시
+                console.error('Error:', error);
                 document.getElementById('error-message').style.display = 'block';
             });
     });

--- a/src/test/java/uniqram/c1one/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/uniqram/c1one/auth/jwt/JwtTokenProviderTest.java
@@ -40,7 +40,7 @@ class JwtTokenProviderTest {
 
         // then: 토큰 잘 생성됐는지
         assertThat(jwt).isNotNull();
-        assertThat(jwt.getGrantType()).isEqualTo("Bearer");
+        assertThat(jwt.getTokenType()).isEqualTo("Bearer");
         assertThat(jwt.getAccessToken()).isNotBlank();
         assertThat(jwt.getRefreshToken()).isNotBlank();
 

--- a/src/test/java/uniqram/c1one/follow/service/FollowServiceTest.java
+++ b/src/test/java/uniqram/c1one/follow/service/FollowServiceTest.java
@@ -34,7 +34,6 @@ class FollowServiceTest {
         Users users = Users.builder()
                 .username(username)
                 .password("password")
-                .email(username + "@test.com")
                 .role(Role.USER)
                 .build();
         return userRepository.save(users);
@@ -199,7 +198,6 @@ class FollowServiceTest {
                 Users.builder()
                         .username("main")
                         .password("pw")
-                        .email("main@test.com")
                         .role(Role.USER)
                         .build()
         );
@@ -209,7 +207,6 @@ class FollowServiceTest {
                     Users.builder()
                             .username("user" + i)
                             .password("pw")
-                            .email("user" + i + "@test.com")
                             .role(Role.USER)
                             .build()
             );


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
로그인을 안해도 index 페이지(로그인 성공 페이지)를 볼 수 있었지만, 인가된 사용자만 볼 수 있게함
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- SecurityConfig 설정 코드 추가 및 예외 처리
- 엑세스 토큰, 리프레시 토큰 유효시간 설정
- WebController 코드 수정
- 테스트 코드에서 email 항목 삭제


## 📸 스크린샷 (선택)
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/2d0b185a-5f53-4f48-b702-efd83d78fe38" />

👉 인가없이 요청하면 리다이렉트


## 💬 공유사항 to 리뷰어
- 로그인 없이 /index 접근하면 로그인 페이지로 리다이렉트
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #85 
<!--- closes #이슈번호 ex) closes #123 -->

