### PR TITLE
[Refactor] 게시글 및 북마크 API @AuthenticationPrincipal 기반으로 리팩터링

### DIFF
--- a/src/main/java/uniqram/c1one/post/controller/BookmarkController.java
+++ b/src/main/java/uniqram/c1one/post/controller/BookmarkController.java
@@ -3,12 +3,14 @@ package uniqram.c1one.post.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.global.success.SuccessResponse;
 import uniqram.c1one.post.dto.BookmarkPostResponse;
 import uniqram.c1one.post.dto.BookmarkRequest;
 import uniqram.c1one.post.exception.BookmarkSuccessCode;
 import uniqram.c1one.post.service.BookmarkService;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 
 import java.util.List;
 
@@ -21,16 +23,19 @@ public class BookmarkController {
 
     @PostMapping
     public ResponseEntity<SuccessResponse<Boolean>> bookmark(
-            @RequestBody @Valid BookmarkRequest bookmarkRequest
+            @RequestBody @Valid BookmarkRequest bookmarkRequest,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        boolean isBookmarked = bookmarkService.bookmark(bookmarkRequest.getUserId(), bookmarkRequest.getPostId());
+        Long userId = userDetails.getUserId();
+        boolean isBookmarked = bookmarkService.bookmark(userId, bookmarkRequest.getPostId());
         return ResponseEntity.ok(SuccessResponse.of(BookmarkSuccessCode.BOOKMARK_TOGGLED, isBookmarked));
     }
 
     @GetMapping
     public ResponseEntity<SuccessResponse<List<BookmarkPostResponse>>> getMyBookmarks(
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        Long userId = userDetails.getUserId();
         List<BookmarkPostResponse> bookmarks = bookmarkService.getMyBookmarks(userId);
         return ResponseEntity.ok(SuccessResponse.of(BookmarkSuccessCode.BOOKMARK_LIST_LOADED, bookmarks));
     }

--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -4,12 +4,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.global.success.SuccessResponse;
 import uniqram.c1one.post.dto.*;
 import uniqram.c1one.post.exception.PostSuccessCode;
 import uniqram.c1one.post.service.PostLikeService;
 import uniqram.c1one.post.service.PostService;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 
 @RestController
 @RequestMapping("/posts")
@@ -21,26 +23,29 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<SuccessResponse<PostResponse>> createPost(
-            @RequestBody @Valid PostCreateRequest postCreateRequest
+            @RequestBody @Valid PostCreateRequest postCreateRequest,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long userId = postCreateRequest.getUserId();
+        Long userId = userDetails.getUserId();
         PostResponse postResponse = postService.createPost(userId, postCreateRequest);
         return ResponseEntity.status(PostSuccessCode.POST_CREATED.getStatus())
                 .body(SuccessResponse.of(PostSuccessCode.POST_CREATED, postResponse));
     }
 
-    @GetMapping("/home/{userId}")
+    @GetMapping("/home")
     public ResponseEntity<Page<HomePostResponse>> getHomePosts(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
+        Long userId = userDetails.getUserId();
         Page<HomePostResponse> homePosts = postService.getHomePosts(userId, page, size);
         return ResponseEntity.ok(homePosts);
     }
 
     @GetMapping("/profile/{userId}")
     public ResponseEntity<Page<UserPostResponse>> getUserPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -51,37 +56,41 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPostDetail(
-            @PathVariable Long postId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long postId
     ) {
+        Long userId = userDetails.getUserId();
         PostDetailResponse postDetailResponse = postService.getPostDetail(userId, postId);
         return ResponseEntity.ok(postDetailResponse);
     }
 
     @PatchMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
             @RequestBody PostUpdateRequest postUpdateRequest
     ) {
-        Long userId = postUpdateRequest.getUserId();
+        Long userId = userDetails.getUserId();
         PostResponse updatedPost = postService.updatePost(userId, postId, postUpdateRequest);
         return ResponseEntity.ok(updatedPost);
     }
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId
     ) {
+        Long userId = userDetails.getUserId();
         postService.deletePost(userId, postId);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{postId}/like")
     public ResponseEntity<PostLikeResponse> likePost(
-            @PathVariable Long postId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long postId
     ){
+        Long userId = userDetails.getUserId();
         PostLikeResponse like = postLikeService.like(userId, postId);
         return ResponseEntity.ok(like);
     }

--- a/src/main/java/uniqram/c1one/post/dto/BookmarkRequest.java
+++ b/src/main/java/uniqram/c1one/post/dto/BookmarkRequest.java
@@ -8,6 +8,5 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookmarkRequest {
 
-    private Long userId;
     private Long postId;
 }

--- a/src/main/java/uniqram/c1one/security/adapter/CustomUserDetails.java
+++ b/src/main/java/uniqram/c1one/security/adapter/CustomUserDetails.java
@@ -48,4 +48,8 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public Long getUserId() {
+        return user.getId();
+    }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
게시글 및 북마크 API의 사용자 인증 방식을 @AuthenticationPrincipal 기반으로 리팩터링했습니다.


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- PostController, BookmarkController에서 userId 파라미터 제거
- @AuthenticationPrincipal CustomUserDetails를 통해 로그인 사용자 정보 전달



## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


----------

closes #113 
