### PR TITLE
[Fix] CustomUserDetails 의 .getUserId() 값이 Null 로 조회되는 현상 해결

### DIFF
--- a/src/test/java/uniqram/c1one/auth/controller/AuthControllerTest.java
+++ b/src/test/java/uniqram/c1one/auth/controller/AuthControllerTest.java
@@ -51,9 +51,9 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("인증되지 않은 사용자 /api/user/test 접근 시 403 Forbidden")
+    @DisplayName("인증되지 않은 사용자 /api/user/test 접근 시 리다이렉트")
     void anonymousAccessUserEndpoint_ShouldForbidden() throws Exception {
         mockMvc.perform(get("/api/user/test"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().is3xxRedirection());
     }
 }

--- a/src/test/java/uniqram/c1one/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/uniqram/c1one/auth/jwt/JwtTokenProviderTest.java
@@ -2,28 +2,41 @@ package uniqram.c1one.auth.jwt;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import uniqram.c1one.auth.dto.JwtToken;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 import uniqram.c1one.security.jwt.JwtTokenProvider;
+import uniqram.c1one.user.entity.Role;
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
 
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 class JwtTokenProviderTest {
 
     private JwtTokenProvider provider;
 
+    @Mock
+    private UserRepository userRepository;
+
     @BeforeEach
     void setUp() {
+        MockitoAnnotations.openMocks(this);
+
         byte[] keyBytes = new byte[32];
         new java.security.SecureRandom().nextBytes(keyBytes);
         String base64Secret = Base64.getEncoder().encodeToString(keyBytes);
 
-        provider = new JwtTokenProvider(base64Secret);
+        provider = new JwtTokenProvider(base64Secret,userRepository);
     }
 
     @Test
@@ -35,12 +48,21 @@ class JwtTokenProviderTest {
                 username, null, Collections.singleton(role)
         );
 
+        Users user = Users.builder()
+                .id(3L)
+                .username(username)
+                .password("dummy")
+                .role(Role.USER)
+                .build();
+
+        // userRepository mock이 username에 대해 위 유저 리턴하도록 설정
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
         // when: 토큰 생성
         JwtToken jwt = provider.generateToken(auth);
 
         // then: 토큰 잘 생성됐는지
         assertThat(jwt).isNotNull();
-        assertThat(jwt.getTokenType()).isEqualTo("Bearer");
         assertThat(jwt.getAccessToken()).isNotBlank();
         assertThat(jwt.getRefreshToken()).isNotBlank();
 
@@ -51,6 +73,40 @@ class JwtTokenProviderTest {
         Authentication parsed = provider.getAuthentication(jwt.getAccessToken());
         assertThat(parsed.getName()).isEqualTo(username);
 
+    }
+
+    @Test
+    void jwt_인증_후_CustomUserDetails_userId_정상() {
+        // given
+        String username = "testuser";
+        Long userId = 42L;
+
+        // 1. Users 엔티티 (id 포함) 생성
+        Users user = Users.builder()
+                .id(userId)
+                .username(username)
+                .password("encodedPassword")
+                .role(Role.USER)
+                .build();
+
+        // 2. userRepository mock 세팅
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        // 3. 인증 정보 생성 및 토큰 발급
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                username, null, Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        JwtToken jwt = provider.generateToken(authentication);
+
+        // 4. JWT 토큰에서 Authentication 복원
+        Authentication authResult = provider.getAuthentication(jwt.getAccessToken());
+
+        // 5. Principal을 CustomUserDetails로 변환
+        CustomUserDetails customUserDetails =
+                (CustomUserDetails) authResult.getPrincipal();
+
+        // then: userId가 DB의 id와 같은지 검증!
+        assertThat(customUserDetails.getUserId()).isEqualTo(userId);
     }
 
     @Test


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
CustomUserDetails 의 .getUserId() 값이 Null 로 조회되는 현상 해결
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- DB에서 findByUsername(username)으로 Users 엔티티를 조회해서, 그걸로 CustomUserDetails를 만들어 인증 객체에 등록


## 📸 스크린샷 (선택)
<img width="580" alt="image" src="https://github.com/user-attachments/assets/0130210b-19db-4800-b0c9-78727f7f8b3e" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #125 
<!--- closes #이슈번호 ex) closes #123 -->

