### PR TITLE
[Refactor] Comment 도메인 @AuthenticationPrincipal 변경

### DIFF
--- a/src/main/java/uniqram/c1one/comment/controller/CommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.comment.dto.CommentCreateRequest;
 import uniqram.c1one.comment.dto.CommentLikeResponse;
@@ -13,6 +14,7 @@ import uniqram.c1one.comment.exception.CommentSuccessCode;
 import uniqram.c1one.comment.service.CommentLikeService;
 import uniqram.c1one.comment.service.CommentService;
 import uniqram.c1one.global.success.SuccessResponse;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 
 import java.util.List;
 
@@ -30,9 +32,10 @@ public class CommentController {
     @PatchMapping
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable Long commentId,
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody CommentUpdateRequest updateRequest
     ) {
+        Long userId = userDetails.getUserId();
         CommentResponse response = commentService.updateComment(userId, commentId, updateRequest);
         return ResponseEntity.ok(response);
     }
@@ -44,7 +47,8 @@ public class CommentController {
     @DeleteMapping
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long commentId,
-            @RequestParam Long userId) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
         commentService.deleteComment(userId, commentId);
         return ResponseEntity.noContent().build();
     }
@@ -55,8 +59,9 @@ public class CommentController {
     @PostMapping("/like")
     public ResponseEntity<CommentLikeResponse> likeComment(
             @PathVariable Long commentId,
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ){
+        Long userId = userDetails.getUserId();
         CommentLikeResponse like = commentLikeService.likeComment(userId, commentId);
         return ResponseEntity.ok(like);
     }

--- a/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
@@ -2,14 +2,17 @@ package uniqram.c1one.comment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.comment.dto.CommentCreateRequest;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.comment.exception.CommentSuccessCode;
 import uniqram.c1one.comment.service.CommentService;
 import uniqram.c1one.global.success.SuccessResponse;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 
 import java.util.List;
 
@@ -24,10 +27,11 @@ public class PostCommentController {
     @ApiResponse(responseCode = "201", description = "생성 성공")
     @PostMapping
     public ResponseEntity<SuccessResponse<CommentResponse>> createComment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
             @RequestBody CommentCreateRequest commentCreateRequest){
-        Long userId = commentCreateRequest.getUserId();
-        CommentResponse response = commentService.createComment(userId, postId,commentCreateRequest);
+        Long userId = userDetails.getUserId();
+        CommentResponse response = commentService.createComment(userId, postId, commentCreateRequest);
         return ResponseEntity.status(CommentSuccessCode.COMMENT_CREATED.getStatus())
                 .body(SuccessResponse.of(CommentSuccessCode.COMMENT_CREATED, response));
     }
@@ -38,5 +42,6 @@ public class PostCommentController {
     public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getComments(postId));
     }
+
 
 }

--- a/src/main/java/uniqram/c1one/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/uniqram/c1one/comment/dto/CommentCreateRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentCreateRequest {
-    private Long userId; //임시 포함
     private Long parentCommentId; //대댓글인 경우
     private String content;
 }

--- a/src/main/java/uniqram/c1one/comment/service/CommentService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentService.java
@@ -35,18 +35,19 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.POST_NOT_FOUND));
 
-        Comment.CommentBuilder commentBuilder = Comment.builder()
-                .user(users)
-                .post(post)
-                .content(createRequest.getContent());
-
+        Comment parentComment = null;
         if (createRequest.getParentCommentId() != null) {
-            Comment parent = commentRepository.findById(createRequest.getParentCommentId())
+            parentComment = commentRepository.findById(createRequest.getParentCommentId())
                     .orElseThrow(() -> new CommentException(CommentErrorCode.PARENT_COMMENT_NOT_FOUND));
-            commentBuilder.parentComment(parent);
         }
 
-        Comment comment = commentRepository.save(commentBuilder.build());
+        Comment comment = Comment.builder()
+                .user(users)
+                .post(post)
+                .parentComment(parentComment)
+                .content(createRequest.getContent())
+                .build();
+        commentRepository.save(comment);
 
         return CommentResponse.builder()
                 .commentId(comment.getId())
@@ -55,7 +56,7 @@ public class CommentService {
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .parentCommentId(
-                        comment.getParentComment() != null ? comment.getParentComment().getId() : null
+                        parentComment != null ? parentComment.getId() : null
                 )
                 .build();
     }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
Comment 도메인의 댓글 생성/수정/삭제/좋아요 API의 매개변수를 @AuthenticationPrincipal로 변경

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- PostCommentController의 userID를 CustomUserDetails로 받도록 변경
- CommentController의 userID를 CustomUserDetails로 받도록 변경
- CommentCreateRequest의 userId 삭제


## 📸 스크린샷 (선택)
![스크린샷 2025-07-03 오전 9 37 44](https://github.com/user-attachments/assets/f3c38d8f-41e0-4331-97aa-165c55b97584)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#115 
