### PR TITLE
[Refactor] 댓글/게시글 좋아요 증감처리 및 조회 기능 redis 적용

### DIFF
--- a/src/main/java/uniqram/c1one/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentLikeRepository.java
@@ -11,4 +11,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     int countByComment(Comment comment);
     boolean existsByUserAndComment(Users user, Comment comment);
     Optional<CommentLike> findByUserAndComment(Users user, Comment comment);
+    int countByCommentId(Long commentId);
 }

--- a/src/main/java/uniqram/c1one/comment/service/CommentLikeService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentLikeService.java
@@ -10,6 +10,7 @@ import uniqram.c1one.comment.exception.CommentErrorCode;
 import uniqram.c1one.comment.exception.CommentException;
 import uniqram.c1one.comment.repository.CommentLikeRepository;
 import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.global.service.LikeCountService;
 import uniqram.c1one.user.entity.Users;
 import uniqram.c1one.user.repository.UserRepository;
 
@@ -22,6 +23,7 @@ public class CommentLikeService {
     private final CommentLikeRepository commentLikeRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final LikeCountService likeCountService;
 
     @Transactional
     public CommentLikeResponse likeComment(Long userId, Long commentId) {
@@ -36,14 +38,16 @@ public class CommentLikeService {
         boolean liked;
         if (existing.isPresent()) {
             commentLikeRepository.delete(existing.get());
+            likeCountService.decrementCommentLike(commentId);
             liked = false;
         } else {
             CommentLike commentLike = CommentLike.builder().user(user).comment(comment).build();
             commentLikeRepository.save(commentLike);
+            likeCountService.incrementCommentLike(commentId);
             liked = true;
         }
 
-        int likeCount = commentLikeRepository.countByComment(comment);
+        int likeCount = likeCountService.getCommentLikeCount(commentId);
 
         return CommentLikeResponse.builder()
                 .commentId(commentId)

--- a/src/main/java/uniqram/c1one/comment/service/CommentService.java
+++ b/src/main/java/uniqram/c1one/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import uniqram.c1one.comment.exception.CommentErrorCode;
 import uniqram.c1one.comment.exception.CommentException;
 import uniqram.c1one.comment.repository.CommentLikeRepository;
 import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.global.service.LikeCountService;
 import uniqram.c1one.post.entity.Post;
 import uniqram.c1one.post.repository.PostRepository;
 import uniqram.c1one.user.entity.Users;
@@ -26,7 +27,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-    private final CommentLikeRepository commentLikeRepository;
+    private final LikeCountService likeCountService;
 
     public CommentResponse createComment(Long userId, Long postId, CommentCreateRequest createRequest) {
         Users users = userRepository.findById(userId)
@@ -70,7 +71,7 @@ public class CommentService {
 
 
         return comments.stream()
-                .map(comment -> { int likeCount = commentLikeRepository.countByComment(comment);
+                .map(comment -> { int likeCount = likeCountService.getCommentLikeCount(comment.getId());
                         return CommentResponse.builder()
                         .commentId(comment.getId())
                         .userName(comment.getUser().getUsername())

--- a/src/main/java/uniqram/c1one/global/service/LikeCountService.java
+++ b/src/main/java/uniqram/c1one/global/service/LikeCountService.java
@@ -1,0 +1,65 @@
+package uniqram.c1one.global.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import uniqram.c1one.comment.repository.CommentLikeRepository;
+import uniqram.c1one.post.repository.PostLikeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LikeCountService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+
+    private static final String POST_LIKE_KEY_PREFIX = "post:like:";
+    private static final String COMMENT_LIKE_KEY_PREFIX = "comment:like:";
+
+    public int getPostLikeCount(Long postId) {
+        String key = POST_LIKE_KEY_PREFIX + postId;
+        String value = redisTemplate.opsForValue().get(key);
+
+        if(value != null) {
+            return Integer.parseInt(value);
+        } else {
+            int count = postLikeRepository.countByPostId(postId);
+            redisTemplate.opsForValue().set(key, String.valueOf(count));
+            return count;
+        }
+    }
+
+    public int getCommentLikeCount(Long commentId) {
+        String key = COMMENT_LIKE_KEY_PREFIX + commentId;
+        String value = redisTemplate.opsForValue().get(key);
+        if(value != null) {
+            return Integer.parseInt(value);
+        } else {
+            int count = commentLikeRepository.countByCommentId(commentId);
+            redisTemplate.opsForValue().set(key, String.valueOf(count));
+            return count;
+        }
+    }
+
+    public void incrementPostLike(Long postId) {
+        String key = POST_LIKE_KEY_PREFIX + postId;
+        redisTemplate.opsForValue().increment(key, 1);
+    }
+
+    public void decrementPostLike(Long postId) {
+        String key = POST_LIKE_KEY_PREFIX + postId;
+        redisTemplate.opsForValue().decrement(key, 1);
+    }
+
+    public void incrementCommentLike(Long commentId) {
+        String key = COMMENT_LIKE_KEY_PREFIX + commentId;
+        redisTemplate.opsForValue().increment(key, 1);
+    }
+
+    public void decrementCommentLike(Long commentId) {
+        String key = COMMENT_LIKE_KEY_PREFIX + commentId;
+        redisTemplate.opsForValue().decrement(key, 1);
+    }
+
+}

--- a/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostLikeRepository.java
@@ -18,6 +18,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     int countByPost(Post post);
     boolean existsByUserAndPost(Users user, Post post);
     Optional<PostLike> findByUserAndPost(Users user, Post post);
+    int countByPostId(Long postId);
 
     @Query("SELECT new uniqram.c1one.post.dto.LikeCountDto(pl.post.id, COUNT(pl)) " +
             "FROM PostLike pl WHERE pl.post.id IN :postIds GROUP BY pl.post.id")

--- a/src/main/java/uniqram/c1one/post/service/PostLikeService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostLikeService.java
@@ -3,6 +3,7 @@ package uniqram.c1one.post.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.global.service.LikeCountService;
 import uniqram.c1one.post.dto.PostLikeResponse;
 import uniqram.c1one.post.entity.Post;
 import uniqram.c1one.post.entity.PostLike;
@@ -21,6 +22,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final LikeCountService likeCountService;
 
     @Transactional
     public PostLikeResponse like(Long userId, Long postId) {
@@ -34,6 +36,7 @@ public class PostLikeService {
         boolean liked;
         if (existing.isPresent()) {
             postLikeRepository.delete(existing.get());
+            likeCountService.decrementPostLike(postId);
             liked = false;
         } else {
             PostLike postLike = PostLike.builder()
@@ -41,9 +44,10 @@ public class PostLikeService {
                     .post(post)
                     .build();
             postLikeRepository.save(postLike);
+            likeCountService.incrementPostLike(postId);
             liked = true;
         }
-        int likeCount = postLikeRepository.countByPost(post);
+        int likeCount = likeCountService.getPostLikeCount(postId);
 
         return PostLikeResponse.builder()
                 .postId(postId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ server:
       force: true
 
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
   config:
     import:
       - optional:file:./env/db.env.properties


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
댓글/게시글 좋아요 증감처리 및 조회 기능 redis 적용

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- application.yml 파일에 redis host,port 설정(Redis 적용 테스트 시에는 로컬환경에서 Redis 서버가 켜져있어야 합니다.)
- global 패키지에 service 패키지 생성, LikeCountService 생성
- LikeCountService는 redisTemplate를 적용한 댓글/게시글 좋아요 증감처리 및 조회 기능 
- 댓글/게시글 좋아요 관련 서비스에 적용

## 📸 스크린샷 (선택)
- 게시글 좋아요 시, 최초에는 DB와 Redis에 저장(소요시간 246ms)
![스크린샷 2025-07-03 오전 11 42 52](https://github.com/user-attachments/assets/9fcee06d-abee-4dac-be70-54f77617be09)

- 이후 좋아요 취소 및 다시 좋아요 시, Redis에서 캐시 처리(소요시간 26ms)
![스크린샷 2025-07-03 오전 11 43 07](https://github.com/user-attachments/assets/b5dcb72a-f18e-4903-967b-1073ef71b3e7)

- 댓글 좋아요 시, 최초에는 DB와 Redis에 저장(소요시간 232ms)
![스크린샷 2025-07-03 오전 11 51 48](https://github.com/user-attachments/assets/68889cba-2678-426c-8f05-4e1d2d2fc82a)

- 이후 좋아요 취소 및 다시 좋아요 시, Redis에서 캐시 처리(소요시간 29ms)
![스크린샷 2025-07-03 오전 11 52 05](https://github.com/user-attachments/assets/31dadc95-9bf9-4737-9b4d-d0a9d19890a1)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
@ynyejin 
PostService의 getHomePosts()는 현재 좋아요 개수를 postLikeRepository에서 불러와 Map 형식으로 저장.

CommentService의 getComments의 getComments에서는 likeCount를 CommentLikeRepository가 아닌 likeCountService.getCommentLikeCount()로 불러와 redis에서 조회하도록 Refactor 했습니다.

PostService의 getHomePosts() 또한 좋아요 개수를 redis에서 조회 가능하도록 Refactor 할 수 있을지 검토 부탁드립니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#117 

