### PR TITLE
[Feat] Admin 도메인 분리 및 관리자 전용 API 구현

### DIFF
--- a/src/main/java/uniqram/c1one/admin/controller/AdminAuthController.java
+++ b/src/main/java/uniqram/c1one/admin/controller/AdminAuthController.java
@@ -1,0 +1,24 @@
+package uniqram.c1one.admin.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uniqram.c1one.auth.dto.SignupRequest;
+import uniqram.c1one.auth.service.AuthService;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+
+public class AdminAuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signupAdmin(@Valid @RequestBody SignupRequest request) {
+        authService.signupAdmin(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("관리자 계정 생성 완료");
+    }
+}

--- a/src/main/java/uniqram/c1one/admin/controller/AdminDashboardController.java
+++ b/src/main/java/uniqram/c1one/admin/controller/AdminDashboardController.java
@@ -1,0 +1,24 @@
+package uniqram.c1one.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import uniqram.c1one.admin.dto.DashboardResponse;
+import uniqram.c1one.admin.service.AdminDashboardService;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<DashboardResponse> getDashboardStats() {
+        DashboardResponse response = adminDashboardService.getDashboardStats();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/uniqram/c1one/admin/controller/AdminUserController.java
+++ b/src/main/java/uniqram/c1one/admin/controller/AdminUserController.java
@@ -1,0 +1,30 @@
+package uniqram.c1one.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import uniqram.c1one.admin.dto.UserSummaryResponse;
+import uniqram.c1one.admin.service.AdminUserService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping
+    public ResponseEntity<List<UserSummaryResponse>> getAllUsers() {
+        return ResponseEntity.ok(adminUserService.getAllUsers());
+    }
+
+    @GetMapping("/online")
+    public ResponseEntity<List<UserSummaryResponse>> getOnlineUsers() {
+        return ResponseEntity.ok(adminUserService.getOnlineUsers());
+    }
+}

--- a/src/main/java/uniqram/c1one/admin/dto/DashboardResponse.java
+++ b/src/main/java/uniqram/c1one/admin/dto/DashboardResponse.java
@@ -1,0 +1,15 @@
+package uniqram.c1one.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+
+public class DashboardResponse {
+    private long userCount;
+    private long postCount;
+    private long commentCount;
+    private long postLikeCount;
+    private long commentLikeCount;
+}

--- a/src/main/java/uniqram/c1one/admin/dto/UserSummaryResponse.java
+++ b/src/main/java/uniqram/c1one/admin/dto/UserSummaryResponse.java
@@ -1,0 +1,22 @@
+package uniqram.c1one.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import uniqram.c1one.user.entity.Users;
+
+@Getter
+@Builder
+
+public class UserSummaryResponse {
+    private Long id;
+    private String username;
+    private String role;
+
+    public static UserSummaryResponse from(Users user) {
+        return UserSummaryResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .role(user.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
@@ -1,0 +1,32 @@
+package uniqram.c1one.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uniqram.c1one.admin.dto.DashboardResponse;
+import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.comment.repository.CommentLikeRepository;
+import uniqram.c1one.post.repository.PostRepository;
+import uniqram.c1one.post.repository.PostLikeRepository;
+import uniqram.c1one.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+
+public class AdminDashboardService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+
+    public DashboardResponse getDashboardStats() {
+        return DashboardResponse.builder()
+                .userCount(userRepository.count())
+                .postCount(postRepository.count())
+                .commentCount(commentRepository.count())
+                .postLikeCount(postLikeRepository.count())
+                .commentLikeCount(commentLikeRepository.count())
+                .build();
+    }
+}

--- a/src/main/java/uniqram/c1one/admin/service/AdminUserService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminUserService.java
@@ -1,0 +1,30 @@
+package uniqram.c1one.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uniqram.c1one.admin.dto.UserSummaryResponse;
+import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+
+    public List<UserSummaryResponse> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(UserSummaryResponse::from)
+                .toList();
+    }
+
+    public List<UserSummaryResponse> getOnlineUsers() {
+        // 임시: 전체 유저 리턴. redis 적용 후 리펙토링 예정.
+        return userRepository.findAll().stream()
+                .map(UserSummaryResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,6 +20,7 @@ import uniqram.c1one.security.jwt.JwtTokenProvider;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
Admin 도메인 분리 및 관리자 전용 API 구현

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- Admin 도메인 생성 (controller, service, dto 패키지 구성)
- 관리자 회원가입 API Auth에서 Admin으로 이동
- 전체 회원 목록 조회 API 구현
- 관리자 대시보드 통계 API 구현


## 📸 스크린샷 (선택)
![1관리자 회원가입](https://github.com/user-attachments/assets/3c60f43a-df2a-4dcc-831c-c2bd1213814c)

![2관리자 로그인 성공](https://github.com/user-attachments/assets/61de7cfb-6a04-4c78-ad56-9b0ade5322fd)
![3 jwt 토큰 설정 후 전체 회원 목록 조회](https://github.com/user-attachments/assets/b071255c-0850-4b05-95b5-075fda017c63)
![4 대시보드 조회(유저, 게시글, 댓글, 게시글 좋아요, 댓글 좋아요)](https://github.com/user-attachments/assets/856c3964-c3a5-43f6-812a-e9398e878c43)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
접속 중인 유저 목록 조회 부분은 아직 Redis 미도입 상태로 임시로 전체 유저 반환 중입니다.
이후 Redis를 도입 후 리팩토링 예정입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #116 
<!--- closes #이슈번호 ex) closes #123 -->

