### PR TITLE
[Fix] 댓글 조회 시 N+1 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,15 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//쿼리 파라미터 로그 남기기
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
 	// Thymeleaf 템플릿 엔진
 	implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
 
@@ -50,4 +59,21 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/generated/uniqram/c1one/comment/entity/QComment.java
+++ b/src/main/generated/uniqram/c1one/comment/entity/QComment.java
@@ -1,0 +1,73 @@
+package uniqram.c1one.comment.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 525518634L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    public final ListPath<Comment, QComment> childrenComment = this.<Comment, QComment>createList("childrenComment", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final ListPath<CommentLike, QCommentLike> commentLikes = this.<CommentLike, QCommentLike>createList("commentLikes", CommentLike.class, QCommentLike.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final QComment parentComment;
+
+    public final uniqram.c1one.post.entity.QPost post;
+
+    public final uniqram.c1one.user.entity.QUsers user;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parentComment = inits.isInitialized("parentComment") ? new QComment(forProperty("parentComment"), inits.get("parentComment")) : null;
+        this.post = inits.isInitialized("post") ? new uniqram.c1one.post.entity.QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new uniqram.c1one.user.entity.QUsers(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/comment/entity/QCommentLike.java
+++ b/src/main/generated/uniqram/c1one/comment/entity/QCommentLike.java
@@ -1,0 +1,62 @@
+package uniqram.c1one.comment.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCommentLike is a Querydsl query type for CommentLike
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCommentLike extends EntityPathBase<CommentLike> {
+
+    private static final long serialVersionUID = 487278049L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCommentLike commentLike = new QCommentLike("commentLike");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    public final QComment comment;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final uniqram.c1one.user.entity.QUsers user;
+
+    public QCommentLike(String variable) {
+        this(CommentLike.class, forVariable(variable), INITS);
+    }
+
+    public QCommentLike(Path<? extends CommentLike> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCommentLike(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCommentLike(PathMetadata metadata, PathInits inits) {
+        this(CommentLike.class, metadata, inits);
+    }
+
+    public QCommentLike(Class<? extends CommentLike> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.comment = inits.isInitialized("comment") ? new QComment(forProperty("comment"), inits.get("comment")) : null;
+        this.user = inits.isInitialized("user") ? new uniqram.c1one.user.entity.QUsers(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/follow/entity/QFollow.java
+++ b/src/main/generated/uniqram/c1one/follow/entity/QFollow.java
@@ -1,0 +1,56 @@
+package uniqram.c1one.follow.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFollow is a Querydsl query type for Follow
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFollow extends EntityPathBase<Follow> {
+
+    private static final long serialVersionUID = 1375966982L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFollow follow = new QFollow("follow");
+
+    public final DateTimePath<java.time.Instant> createdAt = createDateTime("createdAt", java.time.Instant.class);
+
+    public final uniqram.c1one.user.entity.QUsers follower;
+
+    public final uniqram.c1one.user.entity.QUsers following;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QFollow(String variable) {
+        this(Follow.class, forVariable(variable), INITS);
+    }
+
+    public QFollow(Path<? extends Follow> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFollow(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFollow(PathMetadata metadata, PathInits inits) {
+        this(Follow.class, metadata, inits);
+    }
+
+    public QFollow(Class<? extends Follow> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.follower = inits.isInitialized("follower") ? new uniqram.c1one.user.entity.QUsers(forProperty("follower")) : null;
+        this.following = inits.isInitialized("following") ? new uniqram.c1one.user.entity.QUsers(forProperty("following")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/global/QBaseEntity.java
+++ b/src/main/generated/uniqram/c1one/global/QBaseEntity.java
@@ -1,0 +1,39 @@
+package uniqram.c1one.global;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1584627832L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/post/entity/QBookmark.java
+++ b/src/main/generated/uniqram/c1one/post/entity/QBookmark.java
@@ -1,0 +1,53 @@
+package uniqram.c1one.post.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookmark is a Querydsl query type for Bookmark
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookmark extends EntityPathBase<Bookmark> {
+
+    private static final long serialVersionUID = 327586810L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookmark bookmark = new QBookmark("bookmark");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QPost post;
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QBookmark(String variable) {
+        this(Bookmark.class, forVariable(variable), INITS);
+    }
+
+    public QBookmark(Path<? extends Bookmark> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookmark(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookmark(PathMetadata metadata, PathInits inits) {
+        this(Bookmark.class, metadata, inits);
+    }
+
+    public QBookmark(Class<? extends Bookmark> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/post/entity/QPost.java
+++ b/src/main/generated/uniqram/c1one/post/entity/QPost.java
@@ -1,0 +1,75 @@
+package uniqram.c1one.post.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = -782136988L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    public final NumberPath<Integer> commentCount = createNumber("commentCount", Integer.class);
+
+    public final ListPath<uniqram.c1one.comment.entity.Comment, uniqram.c1one.comment.entity.QComment> comments = this.<uniqram.c1one.comment.entity.Comment, uniqram.c1one.comment.entity.QComment>createList("comments", uniqram.c1one.comment.entity.Comment.class, uniqram.c1one.comment.entity.QComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final BooleanPath disableComments = createBoolean("disableComments");
+
+    public final StringPath Hashtag = createString("Hashtag");
+
+    public final BooleanPath hideLikeAndViewCount = createBoolean("hideLikeAndViewCount");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    public final StringPath location = createString("location");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final uniqram.c1one.user.entity.QUsers user;
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new uniqram.c1one.user.entity.QUsers(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/post/entity/QPostLike.java
+++ b/src/main/generated/uniqram/c1one/post/entity/QPostLike.java
@@ -1,0 +1,62 @@
+package uniqram.c1one.post.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostLike is a Querydsl query type for PostLike
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostLike extends EntityPathBase<PostLike> {
+
+    private static final long serialVersionUID = -921019621L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostLike postLike = new QPostLike("postLike");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final QPost post;
+
+    public final uniqram.c1one.user.entity.QUsers user;
+
+    public QPostLike(String variable) {
+        this(PostLike.class, forVariable(variable), INITS);
+    }
+
+    public QPostLike(Path<? extends PostLike> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostLike(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostLike(PathMetadata metadata, PathInits inits) {
+        this(PostLike.class, metadata, inits);
+    }
+
+    public QPostLike(Class<? extends PostLike> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new uniqram.c1one.user.entity.QUsers(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/post/entity/QPostMedia.java
+++ b/src/main/generated/uniqram/c1one/post/entity/QPostMedia.java
@@ -1,0 +1,53 @@
+package uniqram.c1one.post.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPostMedia is a Querydsl query type for PostMedia
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPostMedia extends EntityPathBase<PostMedia> {
+
+    private static final long serialVersionUID = 1513960672L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPostMedia postMedia = new QPostMedia("postMedia");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath mediaUrl = createString("mediaUrl");
+
+    public final QPost post;
+
+    public QPostMedia(String variable) {
+        this(PostMedia.class, forVariable(variable), INITS);
+    }
+
+    public QPostMedia(Path<? extends PostMedia> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPostMedia(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPostMedia(PathMetadata metadata, PathInits inits) {
+        this(PostMedia.class, metadata, inits);
+    }
+
+    public QPostMedia(Class<? extends PostMedia> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/profile/entity/QProfile.java
+++ b/src/main/generated/uniqram/c1one/profile/entity/QProfile.java
@@ -1,0 +1,55 @@
+package uniqram.c1one.profile.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProfile is a Querydsl query type for Profile
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProfile extends EntityPathBase<Profile> {
+
+    private static final long serialVersionUID = 936610282L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProfile profile = new QProfile("profile");
+
+    public final StringPath bio = createString("bio");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
+    public final uniqram.c1one.user.entity.QUsers userId;
+
+    public QProfile(String variable) {
+        this(Profile.class, forVariable(variable), INITS);
+    }
+
+    public QProfile(Path<? extends Profile> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProfile(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProfile(PathMetadata metadata, PathInits inits) {
+        this(Profile.class, metadata, inits);
+    }
+
+    public QProfile(Class<? extends Profile> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.userId = inits.isInitialized("userId") ? new uniqram.c1one.user.entity.QUsers(forProperty("userId")) : null;
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/search/entity/QSearchHistory.java
+++ b/src/main/generated/uniqram/c1one/search/entity/QSearchHistory.java
@@ -1,0 +1,49 @@
+package uniqram.c1one.search.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QSearchHistory is a Querydsl query type for SearchHistory
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSearchHistory extends EntityPathBase<SearchHistory> {
+
+    private static final long serialVersionUID = -1636394176L;
+
+    public static final QSearchHistory searchHistory = new QSearchHistory("searchHistory");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath searchKeyword = createString("searchKeyword");
+
+    public final NumberPath<Long> userid = createNumber("userid", Long.class);
+
+    public QSearchHistory(String variable) {
+        super(SearchHistory.class, forVariable(variable));
+    }
+
+    public QSearchHistory(Path<? extends SearchHistory> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QSearchHistory(PathMetadata metadata) {
+        super(SearchHistory.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/uniqram/c1one/user/entity/QUsers.java
+++ b/src/main/generated/uniqram/c1one/user/entity/QUsers.java
@@ -1,0 +1,54 @@
+package uniqram.c1one.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUsers is a Querydsl query type for Users
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUsers extends EntityPathBase<Users> {
+
+    private static final long serialVersionUID = -957013895L;
+
+    public static final QUsers users = new QUsers("users");
+
+    public final uniqram.c1one.global.QBaseEntity _super = new uniqram.c1one.global.QBaseEntity(this);
+
+    public final ListPath<uniqram.c1one.comment.entity.Comment, uniqram.c1one.comment.entity.QComment> comments = this.<uniqram.c1one.comment.entity.Comment, uniqram.c1one.comment.entity.QComment>createList("comments", uniqram.c1one.comment.entity.Comment.class, uniqram.c1one.comment.entity.QComment.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public final StringPath username = createString("username");
+
+    public QUsers(String variable) {
+        super(Users.class, forVariable(variable));
+    }
+
+    public QUsers(Path<? extends Users> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUsers(PathMetadata metadata) {
+        super(Users.class, metadata);
+    }
+
+}
+

--- a/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
+++ b/src/main/java/uniqram/c1one/comment/controller/PostCommentController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uniqram.c1one.comment.dto.CommentCreateRequest;
+import uniqram.c1one.comment.dto.CommentListResponse;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.comment.exception.CommentSuccessCode;
 import uniqram.c1one.comment.service.CommentService;
@@ -39,7 +40,7 @@ public class PostCommentController {
     @Operation(summary = "게시글의 전체 댓글 조회", description = "특정 게시글에 달린 모든 댓글을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
+    public ResponseEntity<List<CommentListResponse>> getComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getComments(postId));
     }
 

--- a/src/main/java/uniqram/c1one/comment/dto/CommentListResponse.java
+++ b/src/main/java/uniqram/c1one/comment/dto/CommentListResponse.java
@@ -1,0 +1,25 @@
+package uniqram.c1one.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentListResponse {
+
+    private Long commentId;
+    private Long userId;
+    private String userName;
+    private String content;
+    private int likeCount;
+    private LocalDateTime createdAt;
+//    private LocalDateTime modifiedAt;
+    private Long parentCommentId;
+//    private Long postId;
+}

--- a/src/main/java/uniqram/c1one/comment/entity/Comment.java
+++ b/src/main/java/uniqram/c1one/comment/entity/Comment.java
@@ -42,9 +42,11 @@ public class Comment extends BaseEntity {
     private int likeCount;
 
     @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+    @Builder.Default
     private List<Comment> childrenComment = new ArrayList<>();
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Builder.Default
     private List<CommentLike> commentLikes = new ArrayList<>();
 
     public void update(String content) {

--- a/src/main/java/uniqram/c1one/comment/repository/CommentRepository.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentRepository.java
@@ -3,13 +3,14 @@ package uniqram.c1one.comment.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import uniqram.c1one.comment.dto.CommentListResponse;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.comment.entity.Comment;
 import uniqram.c1one.post.entity.Post;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
     List<Comment> findByPost(Post post);
     List<Comment> findByParentComment(Comment parentComment);
@@ -29,18 +30,20 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "ORDER BY c.post.id, c.createdAt DESC")
     List<CommentResponse> findCommentsByPostIds(@Param("postIds") List<Long> postIds);
 
-    @Query("SELECT new uniqram.c1one.comment.dto.CommentResponse( " +
-            "c.id, " +
-            "c.user.id, " +
-            "c.user.username, " +
-            "c.content, " +
-            "0, " +
-            "c.createdAt, " +
-            "c.modifiedAt, " +
-            "c.parentComment.id, " +
-            "c.post.id) " +
-            "FROM Comment c " +
-            "WHERE c.post.id = :postId " +
-            "ORDER BY c.createdAt ASC")
-    List<CommentResponse> findCommentsByPostId(@Param("postId") Long postId);
+//    @Query("SELECT new uniqram.c1one.comment.dto.CommentResponse( " +
+//            "c.id, " +
+//            "c.user.id, " +
+//            "c.user.username, " +
+//            "c.content, " +
+//            "0, " +
+//            "c.createdAt, " +
+//            "c.modifiedAt, " +
+//            "c.parentComment.id, " +
+//            "c.post.id) " +
+//            "FROM Comment c " +
+//            "WHERE c.post.id = :postId " +
+//            "ORDER BY c.createdAt ASC")
+//    List<CommentResponse> findCommentsByPostId(@Param("postId") Long postId);
+
+    List<CommentListResponse> findCommentsByPostId(Long postId);
 }

--- a/src/main/java/uniqram/c1one/comment/repository/CommentRepository.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentRepository.java
@@ -45,5 +45,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 //            "ORDER BY c.createdAt ASC")
 //    List<CommentResponse> findCommentsByPostId(@Param("postId") Long postId);
 
-    List<CommentListResponse> findCommentsByPostId(Long postId);
 }

--- a/src/main/java/uniqram/c1one/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package uniqram.c1one.comment.repository;
+
+import uniqram.c1one.comment.dto.CommentListResponse;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    List<CommentListResponse> findCommentsByPostId(Long postId);
+}

--- a/src/main/java/uniqram/c1one/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/uniqram/c1one/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,44 @@
+package uniqram.c1one.comment.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import uniqram.c1one.comment.dto.CommentListResponse;
+import uniqram.c1one.comment.entity.QComment;
+import uniqram.c1one.comment.entity.QCommentLike;
+import uniqram.c1one.post.entity.QPost;
+import uniqram.c1one.user.entity.QUsers;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<CommentListResponse> findCommentsByPostId(Long postId) {
+        QComment comment = QComment.comment;
+        QUsers users = QUsers.users;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        CommentListResponse.class,
+                        comment.id,
+                        users.id,
+                        users.username,
+                        comment.content,
+                        Expressions.asNumber(0),
+                        comment.createdAt,
+                        comment.parentComment.id
+                ))
+                .from(comment)
+                .join(comment.user, users)
+                .where(comment.post.id.eq(postId))
+                .orderBy(comment.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/uniqram/c1one/global/config/QuerydslConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package uniqram.c1one.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/uniqram/c1one/post/dto/PostDetailResponse.java
+++ b/src/main/java/uniqram/c1one/post/dto/PostDetailResponse.java
@@ -2,6 +2,7 @@ package uniqram.c1one.post.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import uniqram.c1one.comment.dto.CommentListResponse;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.post.entity.Post;
 
@@ -23,14 +24,14 @@ public class PostDetailResponse {
     private boolean likedByMe;
 
     private int commentCount;
-    private List<CommentResponse> comments;
+    private List<CommentListResponse> comments;
 
     public static PostDetailResponse from(Post post,
-                                        List<String> mediaUrl,
-                                        int likeCount,
-                                        List<LikeUserDto> likeUsers,
-                                        boolean likedByMe,
-                                        List<CommentResponse> comments ) {
+                                          List<String> mediaUrl,
+                                          int likeCount,
+                                          List<LikeUserDto> likeUsers,
+                                          boolean likedByMe,
+                                          List<CommentListResponse> comments ) {
         return PostDetailResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())

--- a/src/main/java/uniqram/c1one/post/service/PostService.java
+++ b/src/main/java/uniqram/c1one/post/service/PostService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uniqram.c1one.comment.dto.CommentListResponse;
 import uniqram.c1one.comment.dto.CommentResponse;
 import uniqram.c1one.comment.repository.CommentRepository;
 import uniqram.c1one.global.service.LikeCountService;
@@ -156,7 +157,7 @@ public class PostService {
 
 //        int commentCount = commentRepository.countByPostId(postId);
 
-        List<CommentResponse> comments = commentRepository.findCommentsByPostId(postId);
+        List<CommentListResponse> comments = commentRepository.findCommentsByPostId(postId);
 
         return PostDetailResponse.from(post, mediaUrls, likeCount, likeUsers, likedByMe, comments);
     }

--- a/src/main/java/uniqram/c1one/user/entity/Users.java
+++ b/src/main/java/uniqram/c1one/user/entity/Users.java
@@ -37,6 +37,7 @@ public class Users extends BaseEntity {
     }
 
     @OneToMany(mappedBy = "user")
+    @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
QueryDSL을 활용한 댓글 조회 시 N+1 문제 해결

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- build.gradle에 QueryDSL 의존성 추가
- uniqram의 Q 객체 생성(c1one/src/main/generated)
- QuerydslConfig 생성(/global/config)
- 각 엔티티의 @OnetoMany로 연관된 List는 @Builder.Default 어노테이션 추가
- CommentRepositoryCustom, CommentRepositoryImpl 생성
- CommentListResponse DTO 생성
- QueryDSL을 통해 DTO를 반환
- 댓글 좋아요는 likeCountService로 반환
- 댓글은 최신순으로 반환


## 📸 스크린샷 (선택)

Postman 테스트 - 조회하려는 게시물의 댓글이 총 3개 일때

- QueryDSL 적용 전:
![스크린샷 2025-07-04 오후 2 37 57](https://github.com/user-attachments/assets/66b72b3f-3abd-4542-b9bf-89541261a0aa)


- QueryDSL 적용 후:
![스크린샷 2025-07-04 오후 2 33 26](https://github.com/user-attachments/assets/ebc40c49-9ecb-4f68-82cd-e0a363ddcaf3)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->

변경된 파일과 생성된 파일이 많습니다. 절반정도는 Q객체 파일이지만 다른 변동 파일도 있으니 확인 부탁드립니다!

@ynyejin 
- PostDetailResponse의 comments 필드를 LIst CommentResponse -> List CommentListResponse 로 변경 
- CommentRepository의  List CommentResponse  findCommentsByPostId()" 주석 처리
- List CommentListResponse findCommentsByPostId()로 사용(메서드를 사용하는 서비스 또한 CommentListResponse 타입으로 받는 findCommentsByPostId()로 변경)

우선 Repository의 같은 메서드는 삭제하지 않고 주석처리를 해놓았습니다. 
postman을 통한 게시물 조회는 변경 후에도 문제없이 작동하였습니다! 그래도 혹시 모르니 변동 파일 확인 부탁드립니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#133 
