### PR TITLE
[Refactor] Redis 기반 접속 중 유저 조회 로직 리팩토링

### DIFF
--- a/src/main/java/uniqram/c1one/admin/dto/DashboardResponse.java
+++ b/src/main/java/uniqram/c1one/admin/dto/DashboardResponse.java
@@ -12,4 +12,5 @@ public class DashboardResponse {
     private long commentCount;
     private long postLikeCount;
     private long commentLikeCount;
+    private long onlineUserCount;
 }

--- a/src/main/java/uniqram/c1one/admin/dto/UserSummaryResponse.java
+++ b/src/main/java/uniqram/c1one/admin/dto/UserSummaryResponse.java
@@ -1,12 +1,14 @@
 package uniqram.c1one.admin.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.redis.model.ActiveUser;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Builder
-
 public class UserSummaryResponse {
     private Long id;
     private String username;
@@ -17,6 +19,13 @@ public class UserSummaryResponse {
                 .id(user.getId())
                 .username(user.getUsername())
                 .role(user.getRole().name())
+                .build();
+    }
+
+    public static UserSummaryResponse from(ActiveUser user) {
+        return UserSummaryResponse.builder()
+                .id(user.getUserId())
+                .username(user.getUsername())
                 .build();
     }
 }

--- a/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
@@ -7,11 +7,11 @@ import uniqram.c1one.comment.repository.CommentRepository;
 import uniqram.c1one.comment.repository.CommentLikeRepository;
 import uniqram.c1one.post.repository.PostRepository;
 import uniqram.c1one.post.repository.PostLikeRepository;
+import uniqram.c1one.redis.service.ActiveUserService;
 import uniqram.c1one.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
-
 public class AdminDashboardService {
 
     private final UserRepository userRepository;
@@ -19,6 +19,7 @@ public class AdminDashboardService {
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final ActiveUserService activeUserService;
 
     public DashboardResponse getDashboardStats() {
         return DashboardResponse.builder()
@@ -27,6 +28,7 @@ public class AdminDashboardService {
                 .commentCount(commentRepository.count())
                 .postLikeCount(postLikeRepository.count())
                 .commentLikeCount(commentLikeRepository.count())
+                .onlineUserCount(activeUserService.countActiveUsers())
                 .build();
     }
 }

--- a/src/main/java/uniqram/c1one/admin/service/AdminUserService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminUserService.java
@@ -3,7 +3,7 @@ package uniqram.c1one.admin.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uniqram.c1one.admin.dto.UserSummaryResponse;
-import uniqram.c1one.user.entity.Users;
+import uniqram.c1one.redis.service.ActiveUserService;
 import uniqram.c1one.user.repository.UserRepository;
 
 import java.util.List;
@@ -14,6 +14,7 @@ import java.util.List;
 public class AdminUserService {
 
     private final UserRepository userRepository;
+    private final ActiveUserService activeUserService;
 
     public List<UserSummaryResponse> getAllUsers() {
         return userRepository.findAll().stream()
@@ -22,8 +23,7 @@ public class AdminUserService {
     }
 
     public List<UserSummaryResponse> getOnlineUsers() {
-        // 임시: 전체 유저 리턴. redis 적용 후 리펙토링 예정.
-        return userRepository.findAll().stream()
+        return activeUserService.getAllActiveUsers().stream()
                 .map(UserSummaryResponse::from)
                 .toList();
     }

--- a/src/main/java/uniqram/c1one/redis/config/RedisConfig.java
+++ b/src/main/java/uniqram/c1one/redis/config/RedisConfig.java
@@ -38,10 +38,13 @@ public class RedisConfig {
         // ObjectMapper에 LocalDateTime 지원
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
+        mapper.activateDefaultTyping(
+                mapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
 
-        // 생성자에 mapper 전달
-        Jackson2JsonRedisSerializer<Object> serializer =
-                new Jackson2JsonRedisSerializer<>(mapper, Object.class);
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        serializer.setObjectMapper(mapper);
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(serializer);
@@ -50,5 +53,4 @@ public class RedisConfig {
 
         return template;
     }
-
 }

--- a/src/main/java/uniqram/c1one/redis/config/RedisConfig.java
+++ b/src/main/java/uniqram/c1one/redis/config/RedisConfig.java
@@ -44,6 +44,7 @@ public class RedisConfig {
         );
 
         Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        // Deprecated된 방식이지만, 캐스팅 문제를 피하기 위해 명시적으로 설정
         serializer.setObjectMapper(mapper);
 
         template.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/uniqram/c1one/redis/service/ActiveUserService.java
+++ b/src/main/java/uniqram/c1one/redis/service/ActiveUserService.java
@@ -60,4 +60,13 @@ public class ActiveUserService {
                 .collect(Collectors.toList());
     }
 
+    public long countActiveUsers() {
+        List<ActiveUser> users = getAllActiveUsers();
+        LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
+
+        return users.stream()
+                .filter(user -> user.getLastAccessTime() != null &&
+                        user.getLastAccessTime().isAfter(fiveMinutesAgo))   // 최근 5분 이내 요청이 있으면 접속 중으로 판단.
+                .count();
+    }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
Redis에 저장된 접속 유저 정보를 기반으로 관리자 대시보드 및 접속 유저 목록 조회 기능 리팩토링

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- ActiveUserService에 접속 중인 유저 수 계산 메서드 추가  
- 관리자 대시보드(DashboardResponse, AdminDashboardService)에 접속 유저 수 표시 기능 추가  
- AdminUserService에서 전체 유저가 아닌 Redis 기반 접속 유저 목록 조회 기능으로 변경  
- UserSummaryResponse에 ActiveUser 엔티티 대응 생성 메서드 추가


## 📸 스크린샷 (선택)
![2 관리자 로그인](https://github.com/user-attachments/assets/e39fac7a-253c-40a0-b1c1-b8c2a001f5f6)
![3 전체 회원 조회](https://github.com/user-attachments/assets/83669211-90de-4a95-b273-018145d18e9a)
![4 접속 중인 유저 목록 조회](https://github.com/user-attachments/assets/8f49eb1a-db43-472d-8c75-cd13fdc7b7ae)
![5 관리자 대시보드](https://github.com/user-attachments/assets/986fe437-7bbb-438a-ad84-bc85cdea5d15)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #145 
<!--- closes #이슈번호 ex) closes #123 -->

