### PR TITLE
[Feat] 홈화면 팔로잉된 사람들의 게시물만 조회 기능 추가

### DIFF
--- a/src/main/java/uniqram/c1one/follow/repository/FollowRepository.java
+++ b/src/main/java/uniqram/c1one/follow/repository/FollowRepository.java
@@ -44,5 +44,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     """)
     List<FollowDto> findFollowingsByUserId(@Param("userId") Long userId);
 
-
+    @Query("""
+    SELECT u.id
+    FROM Follow f
+    JOIN f.follower u
+    WHERE f.following.id = :userId
+""")
+    List<Long> findFollowerIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/uniqram/c1one/post/controller/PostController.java
+++ b/src/main/java/uniqram/c1one/post/controller/PostController.java
@@ -13,6 +13,8 @@ import uniqram.c1one.post.service.PostLikeService;
 import uniqram.c1one.post.service.PostService;
 import uniqram.c1one.security.adapter.CustomUserDetails;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/posts")
 @RequiredArgsConstructor
@@ -33,13 +35,11 @@ public class PostController {
     }
 
     @GetMapping("/home")
-    public ResponseEntity<Page<HomePostResponse>> getHomePosts(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+    public ResponseEntity<List<HomePostResponse>> getFollowingRecentPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
-        Page<HomePostResponse> homePosts = postService.getHomePosts(userId, page, size);
+        List<HomePostResponse> homePosts = postService.getFollowingRecentPosts(userId);
         return ResponseEntity.ok(homePosts);
     }
 

--- a/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostMediaRepository.java
@@ -21,10 +21,10 @@ public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
     @Query(value = "SELECT pm.* " +
             "FROM post_media pm " +
             "INNER JOIN ( " +
-            "   SELECT post_id, MIN(id) AS min_id " +
+            "   SELECT post_id, MIN(post_media_id) AS min_id " +
             "   FROM post_media " +
             "   WHERE post_id IN :postIds " +
             "   GROUP BY post_id " +
-            ") first_pm ON pm.id = first_pm.min_id", nativeQuery = true)
+            ") first_pm ON pm.post_media_id = first_pm.min_id", nativeQuery = true)
     List<PostMedia> findFirstImagesByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/uniqram/c1one/post/repository/PostRepository.java
+++ b/src/main/java/uniqram/c1one/post/repository/PostRepository.java
@@ -3,8 +3,13 @@ package uniqram.c1one.post.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uniqram.c1one.post.entity.Post;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -14,4 +19,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 특정 사용자의 게시글 리스트
     Page<Post> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.user.id IN :userIds AND p.createdAt >= :after ORDER BY p.id DESC")
+    List<Post> findRecentPostsByUserIds(@Param("userIds") List<Long> userIds,
+                                        @Param("after") LocalDateTime after,
+                                        Pageable pageable);
 }

--- a/src/test/java/uniqram/c1one/post/PostServiceTest.java
+++ b/src/test/java/uniqram/c1one/post/PostServiceTest.java
@@ -1,8 +1,6 @@
 package uniqram.c1one.post;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
@@ -16,12 +14,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import uniqram.c1one.comment.repository.CommentRepository;
+import uniqram.c1one.follow.repository.FollowRepository;
 import uniqram.c1one.global.s3.S3Service;
 import uniqram.c1one.global.service.LikeCountService;
 import uniqram.c1one.post.dto.*;
@@ -58,6 +53,9 @@ public class PostServiceTest {
 
     @Mock
     private LikeCountService likeCountService;
+
+    @Mock
+    private FollowRepository followRepository;
 
     @Mock
     private S3Service s3Service;
@@ -130,30 +128,23 @@ public class PostServiceTest {
     }
 
     @Test
-    @DisplayName("홈 게시물 목록 조회 성공")
-    void getHomePosts_success() {
+    @DisplayName("팔로잉 중인 유저의 게시물 목록 조회 성공")
+    void getFollowingRecentPosts_success() {
         // given
         Long userId = 1L;
-        int page = 0;
-        int size = 5;
+
+        List<Long> followingIds = List.of(2L, 3L);
 
         List<Post> postList = List.of(
-                Post.of(Users.builder().id(userId).build(), "내용1", "서울"),
-                Post.of(Users.builder().id(userId).build(), "내용2", "부산")
+                Post.of(Users.builder().id(2L).build(), "내용1", "서울"),
+                Post.of(Users.builder().id(3L).build(), "내용2", "부산")
         );
         ReflectionTestUtils.setField(postList.get(0), "id", 1L);
         ReflectionTestUtils.setField(postList.get(1), "id", 2L);
 
-        Page<Post> postPage = new PageImpl<>(postList);
-
         List<PostMedia> mediaList = List.of(
                 PostMedia.of(postList.get(0), "url1"),
                 PostMedia.of(postList.get(1), "url2")
-        );
-
-        List<LikeCountDto> likeCountList = List.of(
-                new LikeCountDto(1L, 3L),
-                new LikeCountDto(2L, 5L)
         );
 
         List<LikeUserDto> likeUserList = List.of(
@@ -164,8 +155,8 @@ public class PostServiceTest {
 
         List<Long> likedPostIds = List.of(1L);
 
-        // when
-        when(postRepository.findAllByOrderByIdDesc(any(Pageable.class))).thenReturn(postPage);
+        when(followRepository.findFollowerIdsByUserId(userId)).thenReturn(followingIds);
+        when(postRepository.findRecentPostsByUserIds(eq(followingIds), any(), any())).thenReturn(postList);
         when(postMediaRepository.findByPostIdIn(anyList())).thenReturn(mediaList);
         when(likeCountService.getPostLikeCount(1L)).thenReturn(3);
         when(likeCountService.getPostLikeCount(2L)).thenReturn(5);
@@ -173,51 +164,48 @@ public class PostServiceTest {
         when(postLikeRepository.findPostIdsLikedByUser(anyList(), eq(userId))).thenReturn(likedPostIds);
         when(commentRepository.findCommentsByPostIds(anyList())).thenReturn(List.of());
 
-        // then
-        Page<HomePostResponse> responsePage = postService.getHomePosts(userId, page, size);
+        // when
+        List<HomePostResponse> responses = postService.getFollowingRecentPosts(userId);
 
-        assertEquals(2, responsePage.getTotalElements());
-        List<HomePostResponse> responses = responsePage.getContent();
+        // then
+        assertEquals(2, responses.size());
 
         assertEquals(1L, responses.get(0).getPostId());
         assertEquals(3, responses.get(0).getLikeCount());
-        assertEquals(true, responses.get(0).isLikedByMe());
+        assertTrue(responses.get(0).isLikedByMe());
         assertEquals(List.of("url1"), responses.get(0).getMediaUrls());
         assertEquals(2, responses.get(0).getLikeUsers().size());
 
         assertEquals(2L, responses.get(1).getPostId());
         assertEquals(5, responses.get(1).getLikeCount());
-        assertEquals(false, responses.get(1).isLikedByMe());
+        assertFalse(responses.get(1).isLikedByMe());
         assertEquals(List.of("url2"), responses.get(1).getMediaUrls());
         assertEquals(1, responses.get(1).getLikeUsers().size());
 
-        verify(postRepository).findAllByOrderByIdDesc(any(Pageable.class));
+        verify(followRepository).findFollowerIdsByUserId(userId);
+        verify(postRepository).findRecentPostsByUserIds(eq(followingIds), any(), any());
         verify(postMediaRepository).findByPostIdIn(anyList());
         verify(postLikeRepository).findLikeUsersByPostIds(anyList());
         verify(postLikeRepository).findPostIdsLikedByUser(anyList(), eq(userId));
     }
 
     @Test
-    @DisplayName("홈 게시물 조회 - 게시물이 없는 경우 빈 리스트 반환")
-    void get_home_fail_posts_empty() {
+    @DisplayName("팔로잉 중인 유저의 게시물 목록 조회 실패 - 게시물이 없는 경우 빈 리스트 반환")
+    void getFollowingRecentPosts_empty() {
         // given
         Long userId = 1L;
-        int page = 0;
-        int size = 10;
 
-        Page<Post> emptyPage = Page.empty(PageRequest.of(page, size));
-
-        when(postRepository.findAllByOrderByIdDesc(any(Pageable.class))).thenReturn(emptyPage);
-        when(postMediaRepository.findByPostIdIn(Collections.emptyList())).thenReturn(Collections.emptyList());
-        when(postLikeRepository.findLikeUsersByPostIds(Collections.emptyList())).thenReturn(Collections.emptyList());
-        when(postLikeRepository.findPostIdsLikedByUser(Collections.emptyList(), userId)).thenReturn(Collections.emptyList());
+        when(followRepository.findFollowerIdsByUserId(userId)).thenReturn(List.of(2L, 3L));
+        when(postRepository.findRecentPostsByUserIds(anyList(), any(), any())).thenReturn(Collections.emptyList());
 
         // when
-        Page<HomePostResponse> responsePage = postService.getHomePosts(userId, page, size);
+        List<HomePostResponse> responses = postService.getFollowingRecentPosts(userId);
 
         // then
-        assertEquals(0, responsePage.getTotalElements());
-        verify(postLikeRepository, atMostOnce()).countByPostIds(anyList());
+        assertEquals(0, responses.size());
+
+        verify(followRepository).findFollowerIdsByUserId(userId);
+        verify(postRepository).findRecentPostsByUserIds(anyList(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
홈화면 팔로잉된 사람들의 최근 게시물 조회 기능 추가

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- FollowRepository에서 팔로잉 대상의 userId 조회 메서드 추가

- 기존 홈화면 조회 메서드에서 "특정 유저가 팔로잉한 사람들의 최근 4일 이내 게시물 최대 5개 조회"로 로직 개선

- 팔로잉한 사람이 없거나 최근 게시물이 없는 경우 빈 리스트 반환



## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
이후 추천 게시물 조회는 별도 API로 구현 예정입니다.

+ @csyhorizon 
FollowRepository에 List<Long> findFollowerIdsByUserId(@Param("userId") Long userId); 메서드 추가했습니다. 확인 부탁드립니다!


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


---------

closes #154 
