### PR TITLE
[Feat] [Refactor] refresh token 값을 DB에 저장하고 refresh token 생성값 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ env/
 
 src/main/java/uniqram/c1one/test
 src/main/resources/templates/signinTh.html
+.github
+/src/main/generated/

--- a/src/main/java/uniqram/c1one/auth/controller/AuthController.java
+++ b/src/main/java/uniqram/c1one/auth/controller/AuthController.java
@@ -85,6 +85,45 @@ public class AuthController {
 
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(@CookieValue(name = "refresh_token", required = false) String refreshToken,
+                                         HttpServletResponse response) {
+        if (refreshToken == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("리프레시 토큰이 없습니다."));
+        }
+
+        try {
+            // 리프레시 토큰을 사용하여 새로운 토큰 발급
+            JwtToken jwtToken = jwtTokenProvider.refreshToken(refreshToken);
+
+            // 새로운 토큰을 쿠키에 설정
+            Cookie accessTokenCookie = new Cookie("access_token", jwtToken.getAccessToken());
+            accessTokenCookie.setHttpOnly(true);
+            accessTokenCookie.setPath("/");
+            accessTokenCookie.setMaxAge(3600); // 1시간
+
+            Cookie refreshTokenCookie = new Cookie("refresh_token", jwtToken.getRefreshToken());
+            refreshTokenCookie.setHttpOnly(true);
+            refreshTokenCookie.setPath("/");
+            refreshTokenCookie.setMaxAge(14 * 24 * 3600); // 14일
+
+            response.addCookie(accessTokenCookie);
+            response.addCookie(refreshTokenCookie);
+
+            Map<String, Object> responseBody = new HashMap<>();
+            responseBody.put("accessToken", jwtToken.getAccessToken());
+            responseBody.put("message", "토큰 갱신 성공");
+
+            return ResponseEntity.ok(responseBody);
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("토큰 갱신 실패: " + e.getMessage()));
+        }
+    }
+
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@CookieValue(name = "access_token", required = false) Cookie accessTokenCookie,
                                     HttpServletResponse response,
@@ -105,6 +144,9 @@ public class AuthController {
             // Redis에서 활성 사용자 제거
             if (userDetails != null) {
                 System.out.println(">>> userDetails: " + userDetails.getUsername());
+                // 데이터베이스에서 리프레시 토큰 삭제
+                jwtTokenProvider.deleteRefreshTokenByUsername(userDetails.getUsername());
+                // Redis에서 활성 사용자 제거
                 activeUserService.removeActiveUser(userDetails.getUserId());
             }else {
                 System.out.println(">>> userDetails가 null 입니다.");

--- a/src/main/java/uniqram/c1one/security/jwt/entity/RefreshToken.java
+++ b/src/main/java/uniqram/c1one/security/jwt/entity/RefreshToken.java
@@ -1,0 +1,40 @@
+package uniqram.c1one.security.jwt.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import uniqram.c1one.global.BaseEntity;
+import uniqram.c1one.user.entity.Users;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "refresh_tokens")
+public class RefreshToken extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String token;
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+    
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+    
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+    
+    public void updateToken(String token, LocalDateTime expiryDate) {
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/uniqram/c1one/security/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/uniqram/c1one/security/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,18 @@
+package uniqram.c1one.security.jwt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uniqram.c1one.security.jwt.entity.RefreshToken;
+import uniqram.c1one.user.entity.Users;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    
+    Optional<RefreshToken> findByToken(String token);
+    
+    Optional<RefreshToken> findByUser(Users user);
+    
+    void deleteByUser(Users user);
+}


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
1. 리프레시 토큰 값을 DB에 저장
2. 기존의 리프레시 토큰값은 고유한 값이 아니라 모든 사용자가 똑같아서 고유한 값이 발급되도록 변경
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 리프레시 토큰을 저장하는 테이블 생성하고 그곳에 발급과 동시에 값 저장
- 리프레시 토큰 값을 사용자마다 고유한 값이 발급되도록 리팩토링


## 📸 스크린샷 (선택)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
close #161 
<!--- closes #이슈번호 ex) closes #123 -->

