### PR TITLE
[Refactor] 관리자 대시보드 좋아요 수 Redis 기반 조회로 변경

### DIFF
--- a/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
@@ -1,34 +1,52 @@
 package uniqram.c1one.admin.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import uniqram.c1one.admin.dto.DashboardResponse;
-import uniqram.c1one.comment.repository.CommentRepository;
-import uniqram.c1one.comment.repository.CommentLikeRepository;
-import uniqram.c1one.post.repository.PostRepository;
-import uniqram.c1one.post.repository.PostLikeRepository;
 import uniqram.c1one.redis.service.ActiveUserService;
 import uniqram.c1one.user.repository.UserRepository;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class AdminDashboardService {
 
     private final UserRepository userRepository;
-    private final PostRepository postRepository;
-    private final CommentRepository commentRepository;
-    private final PostLikeRepository postLikeRepository;
-    private final CommentLikeRepository commentLikeRepository;
+    private final StringRedisTemplate redisTemplate;
     private final ActiveUserService activeUserService;
 
     public DashboardResponse getDashboardStats() {
+        long userCount = userRepository.count();
+        long postCount = getApproxCount("post:*");
+        long commentCount = getApproxCount("comment:*");
+        long postLikeCount = getTotalLikeCount("post:like:*");
+        long commentLikeCount = getTotalLikeCount("comment:like:*");
+        long onlineUserCount = activeUserService.countActiveUsers();
+
         return DashboardResponse.builder()
-                .userCount(userRepository.count())
-                .postCount(postRepository.count())
-                .commentCount(commentRepository.count())
-                .postLikeCount(postLikeRepository.count())
-                .commentLikeCount(commentLikeRepository.count())
-                .onlineUserCount(activeUserService.countActiveUsers())
+                .userCount(userCount)
+                .postCount(postCount)
+                .commentCount(commentCount)
+                .postLikeCount(postLikeCount)
+                .commentLikeCount(commentLikeCount)
+                .onlineUserCount(onlineUserCount)
                 .build();
+    }
+
+    private int getTotalLikeCount(String pattern) {
+        Set<String> keys = redisTemplate.keys(pattern);
+        if (keys == null || keys.isEmpty()) return 0;
+
+        return keys.stream()
+                .map(redisTemplate.opsForValue()::get)
+                .filter(value -> value != null)
+                .mapToInt(Integer::parseInt)
+                .sum();
+    }
+
+    private long getApproxCount(String pattern) {
+        Set<String> keys = redisTemplate.keys(pattern);
+        return keys != null ? keys.size() : 0;
     }
 }

--- a/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
+++ b/src/main/java/uniqram/c1one/admin/service/AdminDashboardService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import uniqram.c1one.admin.dto.DashboardResponse;
 import uniqram.c1one.redis.service.ActiveUserService;
 import uniqram.c1one.user.repository.UserRepository;
+
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -36,17 +38,17 @@ public class AdminDashboardService {
 
     private int getTotalLikeCount(String pattern) {
         Set<String> keys = redisTemplate.keys(pattern);
-        if (keys == null || keys.isEmpty()) return 0;
+        if (keys.isEmpty()) return 0;
 
         return keys.stream()
                 .map(redisTemplate.opsForValue()::get)
-                .filter(value -> value != null)
+                .filter(Objects::nonNull)
                 .mapToInt(Integer::parseInt)
                 .sum();
     }
 
     private long getApproxCount(String pattern) {
         Set<String> keys = redisTemplate.keys(pattern);
-        return keys != null ? keys.size() : 0;
+        return keys.size();
     }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
대시보드 통계 중 게시글/댓글 좋아요 수를 Redis에서 조회하도록 리팩토링


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 기존 DB 기반 좋아요 수 카운트를 Redis 기반 조회 방식으로 변경
- Redis 키 패턴 (`post:like:*`, `comment:like:*`)을 통해 값 합산 처리
- Postman 및 redis-cli를 통해 테스트 완료


## 📸 스크린샷 (선택)

![스크린샷 2025-07-08 131441](https://github.com/user-attachments/assets/8e616fcb-d01f-42e0-94a6-64ae3e0d1c48)
![스크린샷 2025-07-08 131450](https://github.com/user-attachments/assets/2db80a9c-2670-46d7-9e79-990f57b5b760)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #162 
<!--- closes #이슈번호 ex) closes #123 -->

