### PR TITLE
[Refactor] 대시보드에 실시간 접속자 수 연동 및 접속자 관리 기능 개선

### DIFF
--- a/src/main/java/uniqram/c1one/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/uniqram/c1one/security/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uniqram.c1one.redis.service.ActiveUserService;
+import uniqram.c1one.security.adapter.CustomUserDetails;
 
 import java.io.IOException;
 
@@ -23,16 +24,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         // Request Header 에서 jwt 토큰 추출
         String token = resolveToken(request);
-        validToken(token);
+        validToken(token, request);
         filterChain.doFilter(request, response);
     }
 
-    private void validToken(String token) {
+    private void validToken(String token, HttpServletRequest request) {
         // 토큰 유효성 검증
         if (token != null && jwtTokenProvider.validateToken(token)) {
             // 인증 정보 생성 및 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // 인증 성공 시 Redis에 접속 정보 등록
+            if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+                String ip = request.getRemoteAddr();
+                activeUserService.addActiveUser(userDetails, ip);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
대시보드에 실시간 접속자 수 및 접속자 목록을 Redis 기반으로 연동

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- JWT 인증 성공 시 현재 사용자 정보를 Redis에 등록
- 접속자의 IP, 로그인 시간, 마지막 접근 시간 등을 함께 저장

## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #173
<!--- closes #이슈번호 ex) closes #123 -->

