### PR TITLE
[Refactor] 로그인 응답 타입 명시 및 예외 처리 개선

### DIFF
--- a/src/main/java/uniqram/c1one/auth/controller/AuthController.java
+++ b/src/main/java/uniqram/c1one/auth/controller/AuthController.java
@@ -45,7 +45,7 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/signin")
-    public ResponseEntity<?> signin(@Valid @RequestBody SigninRequest request,
+    public ResponseEntity<LoginResponse> signin(@Valid @RequestBody SigninRequest request,
                                     HttpServletResponse response,
                                     HttpServletRequest httpRequest) {
         try {
@@ -68,7 +68,6 @@ public class AuthController {
             Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken.getAccessToken());
 
             if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
-
                 if (userDetails.isBlacklisted()) {
                     throw new AuthException(AuthErrorCode.USER_BLACKLISTED);
                 }
@@ -91,16 +90,14 @@ public class AuthController {
 
                 return ResponseEntity.ok(loginResponse);
             } else {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(new ErrorResponse("사용자 인증 정보가 올바르지 않습니다."));
+                throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);
             }
 
         } catch (Exception e) {
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(new ErrorResponse("로그인 실패: " + e.getMessage()));
+            throw new AuthException(AuthErrorCode.SIGNIN_FAILED);
         }
     }
+
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@CookieValue(name = "refresh_token", required = false) String refreshToken,

--- a/src/main/java/uniqram/c1one/auth/exception/AuthErrorCode.java
+++ b/src/main/java/uniqram/c1one/auth/exception/AuthErrorCode.java
@@ -11,7 +11,9 @@ public enum AuthErrorCode implements ErrorCode {
 
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
-    USER_BLACKLISTED(HttpStatus.FORBIDDEN, "블랙리스트에 등록된 사용자입니다.");
+    USER_BLACKLISTED(HttpStatus.FORBIDDEN, "블랙리스트에 등록된 사용자입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "사용자 인증 정보가 올바르지 않습니다."),
+    SIGNIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
로그인 API 응답 타입을 명확히 지정하고, 예외 처리 방식을 `AuthErrorCode` 기반으로 통일

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 로그인 컨트롤러 반환 타입을 `ResponseEntity<LoginResponse>`로 명시  
- 기존 문자열 예외 처리 → `AuthException(AuthErrorCode)` 방식으로 수정  
-


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #202 
<!--- closes #이슈번호 ex) closes #123 -->

