### PR TITLE
[Fix] profile를 profileId로 조회하는 문제 해결

### DIFF
--- a/src/main/java/uniqram/c1one/profile/controller/ProfileController.java
+++ b/src/main/java/uniqram/c1one/profile/controller/ProfileController.java
@@ -28,7 +28,7 @@ public class ProfileController {
 
     @GetMapping("/profiles/{userId}")
     public ProfileResponseDto getProfile(@PathVariable Long userId) {
-        return profileService.getProfileById(userId);
+        return profileService.getProfileByUserId(userId);
     }
 
     @PatchMapping("/profiles/image")

--- a/src/main/java/uniqram/c1one/profile/repository/ProfileRepository.java
+++ b/src/main/java/uniqram/c1one/profile/repository/ProfileRepository.java
@@ -1,7 +1,9 @@
 package uniqram.c1one.profile.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uniqram.c1one.profile.entity.Profile;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    Optional<Profile> findByUserId_Id(Long userId);
 }

--- a/src/main/java/uniqram/c1one/profile/service/ProfileService.java
+++ b/src/main/java/uniqram/c1one/profile/service/ProfileService.java
@@ -26,6 +26,7 @@ public class ProfileService {
     public ProfileResponseDto createProfile(Long userId) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.USER_NOT_FOUND));
+
         final Profile profile = Profile.builder()
                 .userId(user)
                 .bio("")
@@ -35,18 +36,34 @@ public class ProfileService {
         return ProfileResponseDto.from(savedProfile);
     }
 
+    /**
+     * 사용자 ID를 기반으로 프로필을 조회합니다.
+     * 메서드 이름을 getProfileByUserId로 변경하여 의미를 명확히 합니다.
+     *
+     * @param userId 프로필을 조회할 사용자의 ID
+     * @return 조회된 프로필의 응답 DTO
+     */
     @Transactional(readOnly = true)
-    public ProfileResponseDto getProfileById(Long profileId) {
+    public ProfileResponseDto getProfileByUserId(Long userId) { // 메서드 이름 변경
 
-        final Profile profile = profileRepository.findById(profileId)
+        // Users의 userId를 기준으로 Profile을 조회합니다.
+        final Profile profile = profileRepository.findByUserId_Id(userId)
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
         return ProfileResponseDto.from(profile);
     }
 
+    /**
+     * 사용자 ID를 기반으로 프로필 이미지를 업데이트합니다.
+     *
+     * @param userId 프로필 이미지를 업데이트할 사용자의 ID
+     * @param profileImage 새로운 프로필 이미지 파일
+     * @return 업데이트된 프로필의 응답 DTO
+     */
     @Transactional
-    public ProfileResponseDto updateProfileImage(Long profileId, MultipartFile profileImage) {
-        Profile profile = profileRepository.findById(profileId)
+    public ProfileResponseDto updateProfileImage(Long userId, MultipartFile profileImage) { // profileId -> userId
+        // userId를 사용하여 프로필을 찾습니다.
+        Profile profile = profileRepository.findByUserId_Id(userId) // findById -> findByUserId_Id
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
         if (profile.getProfileImageUrl() != null) {
@@ -59,9 +76,17 @@ public class ProfileService {
         return ProfileResponseDto.from(profile);
     }
 
+    /**
+     * 사용자 ID를 기반으로 프로필 정보를 업데이트합니다.
+     *
+     * @param userId 프로필 정보를 업데이트할 사용자의 ID
+     * @param profileUpdateRequestDto 업데이트할 프로필 정보 DTO
+     * @return 업데이트된 프로필의 응답 DTO
+     */
     @Transactional
-    public ProfileResponseDto updateProfile(Long profileId, ProfileUpdateRequestDto profileUpdateRequestDto) {
-        Profile profile = profileRepository.findById(profileId)
+    public ProfileResponseDto updateProfile(Long userId, ProfileUpdateRequestDto profileUpdateRequestDto) { // profileId -> userId
+        // userId를 사용하여 프로필을 찾습니다.
+        Profile profile = profileRepository.findByUserId_Id(userId) // findById -> findByUserId_Id
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
         profile.update(profileUpdateRequestDto.getBio(), profileUpdateRequestDto.getProfileImageUrl());

--- a/src/main/java/uniqram/c1one/profile/service/ProfileService.java
+++ b/src/main/java/uniqram/c1one/profile/service/ProfileService.java
@@ -22,6 +22,12 @@ public class ProfileService {
     private final S3Service s3Service;
     private final UserRepository userRepository;
 
+    /**
+     * 프로필 생성
+     *
+     * @param userId 기반의 프로필 생성
+     * @return 저장된 프로필 정보
+     */
     @Transactional
     public ProfileResponseDto createProfile(Long userId) {
         Users user = userRepository.findById(userId)
@@ -37,16 +43,14 @@ public class ProfileService {
     }
 
     /**
-     * 사용자 ID를 기반으로 프로필을 조회합니다.
-     * 메서드 이름을 getProfileByUserId로 변경하여 의미를 명확히 합니다.
+     * UserId 기반 프로필 조회
      *
      * @param userId 프로필을 조회할 사용자의 ID
      * @return 조회된 프로필의 응답 DTO
      */
     @Transactional(readOnly = true)
-    public ProfileResponseDto getProfileByUserId(Long userId) { // 메서드 이름 변경
+    public ProfileResponseDto getProfileByUserId(Long userId) {
 
-        // Users의 userId를 기준으로 Profile을 조회합니다.
         final Profile profile = profileRepository.findByUserId_Id(userId)
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
@@ -54,7 +58,7 @@ public class ProfileService {
     }
 
     /**
-     * 사용자 ID를 기반으로 프로필 이미지를 업데이트합니다.
+     * 사용자 ID 기반 이미지 수정
      *
      * @param userId 프로필 이미지를 업데이트할 사용자의 ID
      * @param profileImage 새로운 프로필 이미지 파일
@@ -77,7 +81,7 @@ public class ProfileService {
     }
 
     /**
-     * 사용자 ID를 기반으로 프로필 정보를 업데이트합니다.
+     * 사용자 ID를 기반으로 프로필 정보를 업데이트
      *
      * @param userId 프로필 정보를 업데이트할 사용자의 ID
      * @param profileUpdateRequestDto 업데이트할 프로필 정보 DTO

--- a/src/test/java/uniqram/c1one/profile/service/ProfileServiceTest.java
+++ b/src/test/java/uniqram/c1one/profile/service/ProfileServiceTest.java
@@ -50,10 +50,10 @@ class ProfileServiceTest {
     @DisplayName("ProfileService - 프로필 조회 성공")
     void getProfileByIdTest() {
         // given
-        Long profileId = testProfile.getId();
+        Long profileId = testProfile.getUserId().getId();
 
         // when
-        ProfileResponseDto dto = profileService.getProfileById(profileId);
+        ProfileResponseDto dto = profileService.getProfileByUserId(profileId);
 
         // then
         assertNotNull(dto);
@@ -66,7 +66,7 @@ class ProfileServiceTest {
     @DisplayName("ProfileService - 프로필 업데이트 성공")
     void updateProfileTest() {
         // given
-        Long profileId = testProfile.getId();
+        Long profileId = testProfile.getUserId().getId();
         ProfileUpdateRequestDto updateDto = new ProfileUpdateRequestDto("수정된 bio", "NewImageURI");
 
         // when


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약
프로필을 profileId로 조회하고 있던 문제 발견
<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 조회 방식 Users의 userId로 변경
- 테스트 케이스 수정
- 코드 수정


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #219 
<!--- closes #이슈번호 ex) closes #123 -->

