### PR TITLE
[Fix] DaoAuthenticationProvider 명시 등록으로 bcrypt 로그인 문제 해결

### DIFF
--- a/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
+++ b/src/main/java/uniqram/c1one/global/config/SecurityConfig.java
@@ -6,8 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -92,6 +90,11 @@ public class SecurityConfig {
     }
 
     @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(provider, activeUserService);
+    }
+
+    @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         
@@ -104,19 +107,5 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 적용
         
         return source;
-    }
-    @Bean
-    public DaoAuthenticationProvider daoAuthenticationProvider() {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
-        provider.setPasswordEncoder(passwordEncoder());
-        return provider;
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        return http.getSharedObject(AuthenticationManagerBuilder.class)
-                .authenticationProvider(daoAuthenticationProvider())
-                .build();
     }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
DaoAuthenticationProvider를 명시적으로 등록하여 직접 삽입한 계정으 로그인 시 401 에러가 발생하는 문제 해결


## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- DaoAuthenticationProvider Bean 등록
- PasswordEncoder, CustomUserDetailsService를 Provider에 수동 주입
- `AuthenticationManager` 재정의하여 Bean 등록
- 기존 AuthenticationConfiguration 방식 제거


## 📸 스크린샷 (선택)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #231 
<!--- closes #이슈번호 ex) closes #123 -->

